### PR TITLE
Testing Dockerfile uses SQL script on image

### DIFF
--- a/simplerisk-minimal/common/entrypoint.sh
+++ b/simplerisk-minimal/common/entrypoint.sh
@@ -57,9 +57,15 @@ db_setup(){
 
     print_log "initial_setup:info" "Starting database set up"
 
-    print_log "initial_setup:info" "Downloading schema..."
-    SCHEMA_FILE='/tmp/simplerisk.sql'
-    exec_cmd "curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-$(cat /tmp/version).sql > $SCHEMA_FILE" "Could not download schema from Github. Exiting."
+    if [ $(cat /tmp/version) == "testing" ]; then
+        print_log "initial_setup:info" "Testing version detected. Looking for SQL script (simplerisk.sql) at /var/www/simplerisk/..."
+        SCHEMA_FILE='/var/www/simplerisk/simplerisk.sql'
+        exec_cmd "[ -f $SCHEMA_FILE ]" "SQL script not found. Exiting."
+    else
+        print_log "initial_setup:info" "Downloading schema..."
+        SCHEMA_FILE='/tmp/simplerisk.sql'
+        exec_cmd "curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-$(cat /tmp/version).sql > $SCHEMA_FILE" "Could not download schema from Github. Exiting."
+    fi
 
     FIRST_TIME_SETUP_USER="${FIRST_TIME_SETUP_USER:-root}"
     FIRST_TIME_SETUP_PASS="${FIRST_TIME_SETUP_PASS:-root}"


### PR DESCRIPTION
Currently, there is no way to use a custom SQL script (besides the ones on the database repository) to test with Docker when there is a new version on testing.

The current changes will now allow the Docker image to be built with a custom SQL script. It requires the script to be located at /var/www/simplerisk/simplerisk.sql; if not, then the image will launch a failed exit code.