### PR TITLE
Fixing memory limit setting of PHP on simplerisk-minimal

### DIFF
--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -60,6 +60,7 @@ RUN service supervisor restart
 
 # Configure Apache
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /usr/local/etc/php/php.ini-production
+RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 # Create SSL Certificates for Apache SSL
 RUN echo \$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c\${1:-32}) > /tmp/pass_openssl.txt
 RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key


### PR DESCRIPTION
Previously, the simplerisk-minimal image was using the default setting for memory_limit (128M). As SimpleRisk requires 256M, a new configuration file had to be created for this, which will set the new limit to 256M.