### PR TITLE
Adding support for error logs on simplerisk-minimal

### DIFF
--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -61,6 +61,8 @@ RUN service supervisor restart
 # Configure Apache
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /usr/local/etc/php/php.ini-production
 RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+RUN echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
+RUN echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
 # Create SSL Certificates for Apache SSL
 RUN echo \$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c\${1:-32}) > /tmp/pass_openssl.txt
 RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key


### PR DESCRIPTION
Currently, the SimpleRisk minimal image only offers access logs when running `docker logs -f simplerisk`. With this new change, it will create a PHP settings file at `/usr/local/etc/php/conf.d` enabling error logs.

Also, it is possible to filter for error logs by simply running `docker logs -f simplerisk >/dev/null`.