### PR TITLE
Simplerisk-minimal image fix

### DIFF
--- a/simplerisk-minimal/common/entrypoint.sh
+++ b/simplerisk-minimal/common/entrypoint.sh
@@ -54,7 +54,7 @@ set_config(){
     [ -n "${SIMPLERISK_DB_SSL_CERT_PATH:-}" ] && sed -i "s/\('DB_SSL_CERTIFICATE_PATH', '\).*\(');\)/\1$SIMPLERISK_DB_SSL_CERT_PATH\2/g" $CONFIG_PATH || true
 
     # shellcheck disable=SC2015
-    [ "$(cat /tmp/version)" == "testing" ] && exec_cmd "sed -i \"s|//\(define('.*_URL\)|\1|g\" $CONFIG_PATH"
+    [ "$(cat /tmp/version)" == "testing" ] && exec_cmd "sed -i \"s|//\(define('.*_URL\)|\1|g\" $CONFIG_PATH" || true
 }
 
 db_setup(){


### PR DESCRIPTION
The entrypoint script verifies if the image is running on test mode or not. Previously, if the image was not running on testing mode, the script threw an error code 1, exiting the container. Now, it will keep running the script as usual.