### PR TITLE
Build/Push per image and generation script fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
 					node("jenkins") {
 						terminateInstance("${instance_id}")
 					}
-					error("Stopping full build")
+					sendErrorEmail()
 				}
 			}
 		}
@@ -64,7 +64,7 @@ pipeline {
 							node("jenkins") {
 								terminateInstance("${instance_id}")
 							}
-							error("Stopping full build")
+							sendErrorEmail()
 						}
 					}
 				}
@@ -104,7 +104,7 @@ pipeline {
 							}
 						}
 						failure {
-							error("Stopping full build")
+							sendErrorEmail()
 						}
 					}
 				}
@@ -143,7 +143,7 @@ pipeline {
 							node("jenkins") {
 								terminateInstance("${instance_id}")
 							}
-							error("Stopping full build")
+							sendErrorEmail()
 						}
 					}
 				}
@@ -182,11 +182,16 @@ pipeline {
 							}
 						}
 						failure {
-							error("Stopping full build")
+							sendErrorEmail()
 						}
 					}
 				}
 			}
+		}
+	}
+	post {
+		success {
+			sendSuccessEmail()
 		}
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,7 @@ pipeline {
 								if (env.BRANCH_NAME != 'master') {
 									node("jenkins") {
 										terminateInstance("${instance_id}")
+										sleep 20
 									}
 								}
 							}
@@ -139,6 +140,7 @@ pipeline {
 								if (env.BRANCH_NAME != 'master') {
 									node("jenkins") {
 										terminateInstance("${instance_id}")
+										sleep 20
 									}
 								}
 							}
@@ -211,7 +213,7 @@ def getOfficialVersion(String updatesDomain="updates-test") {
 void sendEmail(String message) {
 	mail from: 'jenkins@simplerisk.com', to: "$env.GIT_AUTHOR_EMAIL", bcc: '',  cc: 'pedro@simplerisk.com', replyTo: '',
              subject: """${env.JOB_NAME} (Branch ${env.BRANCH_NAME}) - Build # ${env.BUILD_NUMBER} - ${currentBuild.currentResult}""",
-             body: """Check console output at ${env.BUILD_URL} to view the results (The Blue Ocean option will provide the detailed flow of execution)."""
+             body: "$message"
 }
 
 void sendErrorEmail() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,23 +11,15 @@ pipeline {
 				}
 			}
 		}
-		stage ('Build simplerisk/simplerisk') {
-			parallel {
-				stage ('Build SimpleRisk Ubuntu 18.04') {
-					steps {
-						sh """
-							sudo docker build -t simplerisk/simplerisk -f simplerisk/bionic/Dockerfile simplerisk/
-							sudo docker build -t simplerisk/simplerisk:$current_version -f simplerisk/bionic/Dockerfile simplerisk/
-							sudo docker build -t simplerisk/simplerisk:$current_version-bionic -f simplerisk/bionic/Dockerfile simplerisk/
-						"""
-					}
-				}
-				stage ('Build SimpleRisk Ubuntu 20.04') {
-					steps {
-						sh """
-							sudo docker build -t simplerisk/simplerisk:$current_version-focal -f simplerisk/focal/Dockerfile simplerisk/
-						"""
-					}
+		stage ('Log into Docker Hub') {
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'cb153fa6-2299-4bdb-9ef0-9c3e6382c87a', passwordVariable: 'docker_pass', usernameVariable: 'docker_user')]) {
+					sh '''
+						set +x
+						echo $docker_pass >> /tmp/password.txt
+						cat /tmp/password.txt | sudo docker login --username $docker_user --password-stdin
+						rm /tmp/password.txt
+					'''
 				}
 			}
 			post {
@@ -39,53 +31,35 @@ pipeline {
 				}
 			}
 		}
-		stage ('Build simplerisk/simplerisk-minimal') {
-			parallel {
-				stage ('Build SimpleRisk Minimal PHP 7.2') {
-					steps {
-						sh """
-							sudo docker build -t simplerisk/simplerisk-minimal -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
-							sudo docker build -t simplerisk/simplerisk-minimal:$current_version -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
-							sudo docker build -t simplerisk/simplerisk-minimal:$current_version-php72 -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
-						"""
-					}
-				}
-				stage ('Build SimpleRisk Minimal PHP 7.4') {
-					steps {
-						sh """
-							sudo docker build -t simplerisk/simplerisk-minimal:$current_version-php74 -f simplerisk-minimal/php7.4/Dockerfile simplerisk-minimal/
-						"""
-					}
-				}
-			}
-			post {
-				failure {
-					node("jenkins") {
-						terminateInstance("${instance_id}")
-					}
-					error("Stopping full build")
-				}
-			}
-		}
-		stage ('Docker Hub Images Update') {
-			when {
-				expression {
-					env.BRANCH_NAME == "master"
-				}
-			}
+		stage ('simplerisk/simplerisk') {
 			stages {
-				stage ('Log into Docker Hub') {
-					steps {
-						withCredentials([usernamePassword(credentialsId: 'cb153fa6-2299-4bdb-9ef0-9c3e6382c87a', passwordVariable: 'docker_pass', usernameVariable: 'docker_user')]) {
-							sh '''
-								set +x
-								echo $docker_pass >> /tmp/password.txt
-								cat /tmp/password.txt | sudo docker login --username $docker_user --password-stdin
-								rm /tmp/password.txt
-							'''
+				stage ('Build') {
+					parallel {
+						stage ('SimpleRisk Ubuntu 18.04') {
+							steps {
+								sh """
+									sudo docker build -t simplerisk/simplerisk -f simplerisk/bionic/Dockerfile simplerisk/
+									sudo docker build -t simplerisk/simplerisk:$current_version -f simplerisk/bionic/Dockerfile simplerisk/
+									sudo docker build -t simplerisk/simplerisk:$current_version-bionic -f simplerisk/bionic/Dockerfile simplerisk/
+								"""
+							}
+						}
+						stage ('SimpleRisk Ubuntu 20.04') {
+							steps {
+								sh """
+									sudo docker build -t simplerisk/simplerisk:$current_version-focal -f simplerisk/focal/Dockerfile simplerisk/
+								"""
+							}
 						}
 					}
 					post {
+						success {
+							if (env.BRANCH_NAME != 'master') {
+								node("jenkins") {
+									terminateInstance("${instance_id}")
+								}
+							}
+						}
 						failure {
 							node("jenkins") {
 								terminateInstance("${instance_id}")
@@ -94,7 +68,12 @@ pipeline {
 						}
 					}
 				}
-				stage ('Push images to Docker Hub') {
+				stage ('Push') {
+					when {
+						expression {
+							env.BRANCH_NAME == "master"
+						}
+					}
 					parallel {
 						stage ('Push SimpleRisk latest') {
 							steps {
@@ -116,6 +95,65 @@ pipeline {
 								sh "sudo docker push simplerisk/simplerisk:$current_version-focal"
 							}
 						}
+
+					}
+					post {
+						always {
+							node("jenkins") {
+								terminateInstance("${instance_id}")
+							}
+						}
+						failure {
+							error("Stopping full build")
+						}
+					}
+				}
+			}
+		}
+		stage ('simplerisk/simplerisk-minimal') {
+			stages {
+				stage ('Build') {
+					parallel {
+						stage ('Build SimpleRisk Minimal PHP 7.2') {
+							steps {
+								sh """
+									sudo docker build -t simplerisk/simplerisk-minimal -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
+									sudo docker build -t simplerisk/simplerisk-minimal:$current_version -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
+									sudo docker build -t simplerisk/simplerisk-minimal:$current_version-php72 -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
+								"""
+							}
+						}
+						stage ('Build SimpleRisk Minimal PHP 7.4') {
+							steps {
+								sh """
+									sudo docker build -t simplerisk/simplerisk-minimal:$current_version-php74 -f simplerisk-minimal/php7.4/Dockerfile simplerisk-minimal/
+								"""
+							}
+						}
+					}
+					post {
+						success {
+							if (env.BRANCH_NAME != 'master') {
+								node("jenkins") {
+									terminateInstance("${instance_id}")
+								}
+							}
+						}
+						failure {
+							node("jenkins") {
+								terminateInstance("${instance_id}")
+							}
+							error("Stopping full build")
+						}
+					}
+				}
+				stage ('Push') {
+					when {
+						expression {
+							env.BRANCH_NAME == "master"
+						}
+					}
+					parallel {
 						stage ('Push SimpleRisk Minimal latest') {
 							steps {
 								sh "sudo docker push simplerisk/simplerisk-minimal"
@@ -148,7 +186,6 @@ pipeline {
 						}
 					}
 				}
-
 			}
 		}
 	}
@@ -160,6 +197,20 @@ def getEC2Metadata(String attribute){
 
 def getOfficialVersion(String updatesDomain="updates-test") {
 	return sh(script: "echo \$(curl -sL https://$updatesDomain\\.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1)", returnStdout: true).trim()
+}
+
+void sendEmail(String message) {
+	mail from: 'jenkins@simplerisk.com', to: "$env.GIT_AUTHOR_EMAIL", bcc: '',  cc: 'pedro@simplerisk.com', replyTo: '',
+             subject: """${env.JOB_NAME} (Branch ${env.BRANCH_NAME}) - Build # ${env.BUILD_NUMBER} - ${currentBuild.currentResult}""",
+             body: """Check console output at ${env.BUILD_URL} to view the results (The Blue Ocean option will provide the detailed flow of execution)."""
+}
+
+void sendErrorEmail() {
+	sendEmail("""Build failed at stage \"${env.STAGE_NAME}\". Check console output at ${env.BUILD_URL} to view the results (The Blue Ocean option will provide the detailed execution flow).""")
+}
+
+void sendSuccessEmail() {
+	sendEmail("""Check console output at ${env.BUILD_URL} to view the results (The Blue Ocean option will provide the detailed execution flow).""")
 }
 
 void terminateInstance(String instanceId, String region="us-east-1") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,9 +54,11 @@ pipeline {
 					}
 					post {
 						success {
-							if (env.BRANCH_NAME != 'master') {
-								node("jenkins") {
-									terminateInstance("${instance_id}")
+							script {
+								if (env.BRANCH_NAME != 'master') {
+									node("jenkins") {
+										terminateInstance("${instance_id}")
+									}
 								}
 							}
 						}
@@ -133,9 +135,11 @@ pipeline {
 					}
 					post {
 						success {
-							if (env.BRANCH_NAME != 'master') {
-								node("jenkins") {
-									terminateInstance("${instance_id}")
+							script {
+								if (env.BRANCH_NAME != 'master') {
+									node("jenkins") {
+										terminateInstance("${instance_id}")
+									}
 								}
 							}
 						}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -338,7 +338,7 @@ def getOfficialVersion(String updatesDomain="updates-test") {
 }
 
 void sendEmail(String message) {
-	mail from: 'jenkins@simplerisk.com', to: "$env.GIT_AUTHOR_EMAIL", bcc: '',  cc: 'pedro@simplerisk.com', replyTo: '',
+	mail from: 'jenkins@simplerisk.com', to: """${env.GIT_COMITTER_EMAIL}""", bcc: '',  cc: 'pedro@simplerisk.com', replyTo: '',
              subject: """${env.JOB_NAME} (Branch ${env.BRANCH_NAME}) - Build # ${env.BUILD_NUMBER} - ${currentBuild.currentResult}""",
              body: "$message"
 }

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -61,7 +61,7 @@ COPY common/entrypoint.sh /entrypoint.sh
 RUN service supervisor restart
 
 # Configure Apache
-RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /usr/local/etc/php/php.ini-production
+RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini
 RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 RUN echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
 RUN echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -68,6 +68,8 @@ COPY common/envvars /etc/apache2/envvars
 COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/$php_version/apache2/php.ini
+RUN sed -i 's/\\(upload_max_filesize =\\) .*\\(M\\)/\\1 5\\2/g' /etc/php/$php_version/apache2/php.ini
+RUN sed -i 's/\\(memory_limit =\\) .*\\(M\\)/\\1 256\\2/g' /etc/php/$php_version/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt


### PR DESCRIPTION
The Build/Push process is now separated per images. It prioritizes the Simplerisk image first, then goes with Simplerisk Minimal.

Fixing the following on the generation scripts:
- simplerisk: Using patterns to perform sed replacements.
- simplerisk-minimal: Echoing upload_max_filesize into a config file (as modifying the phi.ini does not work).