### PR TITLE
Jenkinsfile Adaptation and Stack Update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,9 +316,10 @@ void setDockerCreds() {
 			cat /tmp/password.txt | sudo docker login --username $docker_user --password-stdin
 			rm /tmp/password.txt
 		'''
-		}
+	}
 }
 
 void terminateInstance(String instanceId, String region="us-east-1") {
 	sh "aws ec2 terminate-instances --instance-ids $instanceId --region $region"
+	sleep 60
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,8 +44,6 @@ pipeline {
 									image = env.STAGE_NAME
 								}
 								sh """
-									sudo docker build -t simplerisk/simplerisk -f simplerisk/bionic/Dockerfile simplerisk/
-									sudo docker build -t simplerisk/simplerisk:$current_version -f simplerisk/bionic/Dockerfile simplerisk/
 									sudo docker build -t simplerisk/simplerisk:$current_version-bionic -f simplerisk/bionic/Dockerfile simplerisk/
 								"""
 							}
@@ -73,6 +71,8 @@ pipeline {
 									image = env.STAGE_NAME
 								}
 								sh """
+									sudo docker build -t simplerisk/simplerisk -f simplerisk/focal/Dockerfile simplerisk/
+									sudo docker build -t simplerisk/simplerisk:$current_version -f simplerisk/focal/Dockerfile simplerisk/
 									sudo docker build -t simplerisk/simplerisk:$current_version-focal -f simplerisk/focal/Dockerfile simplerisk/
 								"""
 							}
@@ -115,7 +115,18 @@ pipeline {
 						}
 						stage ('Push') {
 							parallel {
-								stage ("Latest/Current Version/Current Version - bionic") {
+								stage ("Current Version - bionic") {
+									agent { label 'buildtestmed' }
+									steps {
+										script {
+											image = env.STAGE_NAME
+										}
+										sh """
+											sudo docker push simplerisk/simplerisk:$current_version-bionic
+										"""
+									}
+								}
+								stage ("Latest/Current Version/Current Version - focal") {
 									agent { label 'buildtestmed' }
 									steps {
 										script {
@@ -124,17 +135,8 @@ pipeline {
 										sh """
 											sudo docker push simplerisk/simplerisk
 											sudo docker push simplerisk/simplerisk:$current_version
-											sudo docker push simplerisk/simplerisk:$current_version-bionic
+											sudo docker push simplerisk/simplerisk:$current_version-focal
 										"""
-									}
-								}
-								stage ("Current Version - focal") {
-									agent { label 'buildtestmed' }
-									steps {
-										script {
-											image = env.STAGE_NAME
-										}
-										sh "sudo docker push simplerisk/simplerisk:$current_version-focal"
 									}
 								}
 							}
@@ -187,8 +189,6 @@ pipeline {
 									image = env.STAGE_NAME
 								}
 								sh """
-									sudo docker build -t simplerisk/simplerisk-minimal -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
-									sudo docker build -t simplerisk/simplerisk-minimal:$current_version -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
 									sudo docker build -t simplerisk/simplerisk-minimal:$current_version-php72 -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
 								"""
 							}
@@ -216,6 +216,8 @@ pipeline {
 									image = env.STAGE_NAME
 								}
 								sh """
+									sudo docker build -t simplerisk/simplerisk-minimal -f simplerisk-minimal/php7.4/Dockerfile simplerisk-minimal/
+									sudo docker build -t simplerisk/simplerisk-minimal:$current_version -f simplerisk-minimal/php7.4/Dockerfile simplerisk-minimal/
 									sudo docker build -t simplerisk/simplerisk-minimal:$current_version-php74 -f simplerisk-minimal/php7.4/Dockerfile simplerisk-minimal/
 								"""
 							}
@@ -258,7 +260,18 @@ pipeline {
 						}
 						stage ('Push') {
 							parallel {
-								stage ('Latest/Current Version/Current Version - PHP 7.2') {
+								stage ('Current Version - PHP 7.2') {
+									agent { label 'buildtestmed' }
+									steps {
+										script {
+											image = env.STAGE_NAME
+										}
+										sh """
+											sudo docker push simplerisk/simplerisk-minimal:$current_version-php72
+										"""
+									}
+								}
+								stage ("Latest/Current Version/Current Version - PHP 7.4") {
 									agent { label 'buildtestmed' }
 									steps {
 										script {
@@ -267,17 +280,8 @@ pipeline {
 										sh """
 											sudo docker push simplerisk/simplerisk-minimal
 											sudo docker push simplerisk/simplerisk-minimal:$current_version
-											sudo docker push simplerisk/simplerisk-minimal:$current_version-php72
+											sudo docker push simplerisk/simplerisk-minimal:$current_version-php74
 										"""
-									}
-								}
-								stage ("Current Version - PHP 7.4") {
-									agent { label 'buildtestmed' }
-									steps {
-										script {
-											image = env.STAGE_NAME
-										}
-										sh "sudo docker push simplerisk/simplerisk-minimal:$current_version-php74"
 									}
 								}
 							}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,15 +58,6 @@ pipeline {
 						}
 					}
 					post {
-						success {
-							script {
-								if (env.BRANCH_NAME != 'master') {
-									node("terminator") {
-										terminateInstance("${instance_id}")
-									}
-								}
-							}
-						}
 						failure {
 							node("terminator") {
 								terminateInstance("${instance_id}")
@@ -97,6 +88,9 @@ pipeline {
 								stage ("Latest/Current Version/Current Version - bionic") {
 									agent { label 'buildtestmed' }
 									steps {
+										script {
+											image = env.STAGE_NAME
+										}
 										sh """
 											sudo docker push simplerisk/simplerisk
 											sudo docker push simplerisk/simplerisk:$current_version
@@ -107,21 +101,29 @@ pipeline {
 								stage ("Current Version - focal") {
 									agent { label 'buildtestmed' }
 									steps {
+										script {
+											image = env.STAGE_NAME
+										}
 										sh "sudo docker push simplerisk/simplerisk:$current_version-focal"
 									}
 								}
 							}
 							post {
-								always {
+								failure {
 									node("terminator") {
 										terminateInstance("${instance_id}")
 									}
-								}
-								failure {
-									sendErrorEmail("${main_stage}/${env.STAGE_NAME}")
+									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}")
 								}
 							}
 						}
+					}
+				}
+			}
+			post {
+				success {
+					node("terminator") {
+						terminateInstance("${instance_id}")
 					}
 				}
 			}
@@ -170,15 +172,6 @@ pipeline {
 						}
 					}
 					post {
-						success {
-							script {
-								if (env.BRANCH_NAME != 'master') {
-									node("terminator") {
-										terminateInstance("${instance_id}")
-									}
-								}
-							}
-						}
 						failure {
 							node("terminator") {
 								terminateInstance("${instance_id}")
@@ -209,6 +202,9 @@ pipeline {
 								stage ('Latest/Current Version/Current Version - PHP 7.2') {
 									agent { label 'buildtestmed' }
 									steps {
+										script {
+											image = env.STAGE_NAME
+										}
 										sh """
 											sudo docker push simplerisk/simplerisk-minimal
 											sudo docker push simplerisk/simplerisk-minimal:$current_version
@@ -219,21 +215,29 @@ pipeline {
 								stage ("Current Version - PHP 7.4") {
 									agent { label 'buildtestmed' }
 									steps {
+										script {
+											image = env.STAGE_NAME
+										}
 										sh "sudo docker push simplerisk/simplerisk-minimal:$current_version-php74"
 									}
 								}
 							}
 							post {
-								always {
+								failure {
 									node("terminator") {
 										terminateInstance("${instance_id}")
 									}
-								}
-								failure {
-									sendErrorEmail("${main_stage}/${env.STAGE_NAME}")
+									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}")
 								}
 							}
 						}
+					}
+				}
+			}
+			post {
+				success {
+					node("terminator") {
+						terminateInstance("${instance_id}")
 					}
 				}
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,39 +94,19 @@ pipeline {
 						}
 						stage ('Push') {
 							parallel {
-								stage ('latest') {
+								stage ("Latest/Current Version/Current Version - bionic") {
 									agent { label 'buildtestmed' }
 									steps {
-										script {
-											image = env.STAGE_NAME
-										}
-										sh "sudo docker push simplerisk/simplerisk"
+										sh """
+											sudo docker push simplerisk/simplerisk
+											sudo docker push simplerisk/simplerisk:$current_version
+											sudo docker push simplerisk/simplerisk:$current_version-bionic
+										"""
 									}
 								}
-								stage ("Current Date") {
+								stage ("Current Version - focal") {
 									agent { label 'buildtestmed' }
 									steps {
-										script {
-											image = env.STAGE_NAME
-										}
-										sh "sudo docker push simplerisk/simplerisk:$current_version"
-									}
-								}
-								stage ("Current Date - bionic") {
-									agent { label 'buildtestmed' }
-									steps {
-										script {
-											image = env.STAGE_NAME
-										}
-										sh "sudo docker push simplerisk/simplerisk:$current_version-bionic"
-									}
-								}
-								stage ("Current Date - focal") {
-									agent { label 'buildtestmed' }
-									steps {
-										script {
-											image = env.STAGE_NAME
-										}
 										sh "sudo docker push simplerisk/simplerisk:$current_version-focal"
 									}
 								}
@@ -138,7 +118,7 @@ pipeline {
 									}
 								}
 								failure {
-									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}")
+									sendErrorEmail("${main_stage}/${env.STAGE_NAME}")
 								}
 							}
 						}
@@ -226,39 +206,19 @@ pipeline {
 						}
 						stage ('Push') {
 							parallel {
-								stage ('latest') {
+								stage ('Latest/Current Version/Current Version - PHP 7.2') {
 									agent { label 'buildtestmed' }
 									steps {
-										script {
-											image = env.STAGE_NAME
-										}
-										sh "sudo docker push simplerisk/simplerisk-minimal"
+										sh """
+											sudo docker push simplerisk/simplerisk-minimal
+											sudo docker push simplerisk/simplerisk-minimal:$current_version
+											sudo docker push simplerisk/simplerisk-minimal:$current_version-php72
+										"""
 									}
 								}
-								stage ("Current Date") {
+								stage ("Current Version - PHP 7.4") {
 									agent { label 'buildtestmed' }
 									steps {
-										script {
-											image = env.STAGE_NAME
-										}
-										sh "sudo docker push simplerisk/simplerisk-minimal:$current_version"
-									}
-								}
-								stage ("Current Date - PHP 7.2") {
-									agent { label 'buildtestmed' }
-									steps {
-										script {
-											image = env.STAGE_NAME
-										}
-										sh "sudo docker push simplerisk/simplerisk-minimal:$current_version-php72"
-									}
-								}
-								stage ("Current Date - PHP 7.4") {
-									agent { label 'buildtestmed' }
-									steps {
-										script {
-											image = env.STAGE_NAME
-										}
 										sh "sudo docker push simplerisk/simplerisk-minimal:$current_version-php74"
 									}
 								}
@@ -270,7 +230,7 @@ pipeline {
 									}
 								}
 								failure {
-									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}")
+									sendErrorEmail("${main_stage}/${env.STAGE_NAME}")
 								}
 							}
 						}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,7 @@ pipeline {
 	agent none
 	stages {
 		stage ('Initializing Common Variables') {
-			agent {
-				// Using ubuntu20 to avoid using master node
-				label 'terminator'
-			}
+			agent { label 'terminator' }
 			steps {
 				script {
 					current_version = getOfficialVersion("updates")
@@ -20,9 +17,7 @@ pipeline {
 		stage ('simplerisk/simplerisk') {
 			stages {
 				stage ('Initialize Variables') {
-					agent {
-						label 'buildtestmed'
-					}
+					agent { label 'buildtestmed' }
 					steps {
 						script {
 							instance_id = getEC2Metadata("instance-id")
@@ -38,9 +33,7 @@ pipeline {
 				stage ('Build') {
 					parallel {
 						stage ('Ubuntu 18.04') {
-							agent {
-								label 'buildtestmed'
-							}
+							agent { label 'buildtestmed' }
 							steps {
 								script {
 									image = env.STAGE_NAME
@@ -53,9 +46,7 @@ pipeline {
 							}
 						}
 						stage ('Ubuntu 20.04') {
-							agent {
-								label 'buildtestmed'
-							}
+							agent { label 'buildtestmed' }
 							steps {
 								script {
 									image = env.STAGE_NAME
@@ -85,16 +76,10 @@ pipeline {
 					}
 				}
 				stage ('Push to Docker Hub') {
-					when {
-						expression {
-							env.BRANCH_NAME == "master"
-						}
-					}
+					when { branch 'master' }
 					stages {
 						stage ('Log into Docker Hub') {
-							agent {
-								label 'buildtestmed'
-							}
+							agent { label 'buildtestmed' }
 							steps {
 								setDockerCreds()
 							}
@@ -110,9 +95,7 @@ pipeline {
 						stage ('Push') {
 							parallel {
 								stage ('latest') {
-									agent {
-										label 'buildtestmed'
-									}
+									agent { label 'buildtestmed' }
 									steps {
 										script {
 											image = env.STAGE_NAME
@@ -121,9 +104,7 @@ pipeline {
 									}
 								}
 								stage ("Current Date") {
-									agent {
-										label 'buildtestmed'
-									}
+									agent { label 'buildtestmed' }
 									steps {
 										script {
 											image = env.STAGE_NAME
@@ -132,9 +113,7 @@ pipeline {
 									}
 								}
 								stage ("Current Date - bionic") {
-									agent {
-										label 'buildtestmed'
-									}
+									agent { label 'buildtestmed' }
 									steps {
 										script {
 											image = env.STAGE_NAME
@@ -143,9 +122,7 @@ pipeline {
 									}
 								}
 								stage ("Current Date - focal") {
-									agent {
-										label 'buildtestmed'
-									}
+									agent { label 'buildtestmed' }
 									steps {
 										script {
 											image = env.STAGE_NAME
@@ -172,9 +149,7 @@ pipeline {
 		stage ('simplerisk/simplerisk-minimal') {
 			stages {
 				stage ('Initialize Variables') {
-					agent {
-						label 'buildtestmed'
-					}
+					agent { label 'buildtestmed' }
 					steps {
 						script {
 							instance_id = getEC2Metadata("instance-id")
@@ -190,9 +165,7 @@ pipeline {
 				stage ('Build') {
 					parallel {
 						stage ('PHP 7.2') {
-							agent {
-								label 'buildtestmed'
-							}
+							agent { label 'buildtestmed' }
 							steps {
 								script {
 									image = env.STAGE_NAME
@@ -205,9 +178,7 @@ pipeline {
 							}
 						}
 						stage ('PHP 7.4') {
-							agent {
-								label 'buildtestmed'
-							}
+							agent { label 'buildtestmed' }
 							steps {
 								script {
 									image = env.STAGE_NAME
@@ -237,16 +208,10 @@ pipeline {
 					}
 				}
 				stage ('Push to Docker Hub') {
-					when {
-						expression {
-							env.BRANCH_NAME == "master"
-						}
-					}
+					when { branch 'master' }
 					stages {
 						stage ('Log into Docker Hub') {
-							agent {
-								label 'buildtestmed'
-							}
+							agent { label 'buildtestmed' }
 							steps {
 								setDockerCreds()
 							}
@@ -262,9 +227,7 @@ pipeline {
 						stage ('Push') {
 							parallel {
 								stage ('latest') {
-									agent {
-										label 'buildtestmed'
-									}
+									agent { label 'buildtestmed' }
 									steps {
 										script {
 											image = env.STAGE_NAME
@@ -273,9 +236,7 @@ pipeline {
 									}
 								}
 								stage ("Current Date") {
-									agent {
-										label 'buildtestmed'
-									}
+									agent { label 'buildtestmed' }
 									steps {
 										script {
 											image = env.STAGE_NAME
@@ -284,9 +245,7 @@ pipeline {
 									}
 								}
 								stage ("Current Date - PHP 7.2") {
-									agent {
-										label 'buildtestmed'
-									}
+									agent { label 'buildtestmed' }
 									steps {
 										script {
 											image = env.STAGE_NAME
@@ -295,9 +254,7 @@ pipeline {
 									}
 								}
 								stage ("Current Date - PHP 7.4") {
-									agent {
-										label 'buildtestmed'
-									}
+									agent { label 'buildtestmed' }
 									steps {
 										script {
 											image = env.STAGE_NAME

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -309,7 +309,7 @@ void sendSuccessEmail() {
 }
 
 void setDockerCreds() {
-	withcredentials([usernamePassword(credentialsid: 'cb153fa6-2299-4bdb-9ef0-9c3e6382c87a', passwordvariable: 'docker_pass', usernamevariable: 'docker_user')]) {
+	withCredentials([usernamePassword(credentialsId: 'cb153fa6-2299-4bdb-9ef0-9c3e6382c87a', passwordVariable: 'docker_pass', usernameVariable: 'docker_user')]) {
 		sh '''
 			set +x
 			echo $docker_pass >> /tmp/password.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -352,7 +352,7 @@ void sendSuccessEmail() {
 }
 
 void setDockerCreds() {
-	withcredentials([usernamepassword(credentialsid: 'cb153fa6-2299-4bdb-9ef0-9c3e6382c87a', passwordvariable: 'docker_pass', usernamevariable: 'docker_user')]) {
+	withcredentials([usernamePassword(credentialsid: 'cb153fa6-2299-4bdb-9ef0-9c3e6382c87a', passwordvariable: 'docker_pass', usernamevariable: 'docker_user')]) {
 		sh '''
 			set +x
 			echo $docker_pass >> /tmp/password.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
 		stage ('Initializing Common Variables') {
 			agent {
 				// Using ubuntu20 to avoid using master node
-				label 'ubuntu20'
+				label 'terminator'
 			}
 			steps {
 				script {
@@ -70,14 +70,14 @@ pipeline {
 						success {
 							script {
 								if (env.BRANCH_NAME != 'master') {
-									node("jenkins") {
+									node("terminator") {
 										terminateInstance("${instance_id}")
 									}
 								}
 							}
 						}
 						failure {
-							node("jenkins") {
+							node("terminator") {
 								terminateInstance("${instance_id}")
 							}
 							sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}")
@@ -100,7 +100,7 @@ pipeline {
 							}
 							post {
 								failure {
-									node("jenkins") {
+									node("terminator") {
 										terminateInstance("${instance_id}")
 									}
 									sendErrorEmail("${main_stage}/${env.STAGE_NAME}")
@@ -156,7 +156,7 @@ pipeline {
 							}
 							post {
 								always {
-									node("jenkins") {
+									node("terminator") {
 										terminateInstance("${instance_id}")
 									}
 								}
@@ -222,14 +222,14 @@ pipeline {
 						success {
 							script {
 								if (env.BRANCH_NAME != 'master') {
-									node("jenkins") {
+									node("terminator") {
 										terminateInstance("${instance_id}")
 									}
 								}
 							}
 						}
 						failure {
-							node("jenkins") {
+							node("terminator") {
 								terminateInstance("${instance_id}")
 							}
 							sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}")
@@ -252,7 +252,7 @@ pipeline {
 							}
 							post {
 								failure {
-									node("jenkins") {
+									node("terminator") {
 										terminateInstance("${instance_id}")
 									}
 									sendErrorEmail("${main_stage}/${env.STAGE_NAME}")
@@ -308,7 +308,7 @@ pipeline {
 							}
 							post {
 								always {
-									node("jenkins") {
+									node("terminator") {
 										terminateInstance("${instance_id}")
 									}
 								}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,11 @@ pipeline {
 					}
 					post {
 						failure {
+							terminateInstance("${instance_id}")
 							sendErrorEmail("${main_stage}/${env.STAGE_NAME}", "${committer_email}")
+						}
+						aborted {
+							terminateInstance("${instance_id}")
 						}
 					}
 				}
@@ -45,6 +49,22 @@ pipeline {
 									sudo docker build -t simplerisk/simplerisk:$current_version-bionic -f simplerisk/bionic/Dockerfile simplerisk/
 								"""
 							}
+							post {
+								success {
+									script {
+										if (env.CHANGE_ID) {
+											pullRequest.createStatus(status: "success", context: "build/simplerisk/ubuntu-1804", description: "Image built successfully", targetUrl: "$BUILD_URL")
+										}
+									}
+								}
+								failure {
+									terminateInstance("${instance_id}")
+									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}", "${committer_email}")
+								}
+								aborted {
+									terminateInstance("${instance_id}")
+								}
+							}
 						}
 						stage ('Ubuntu 20.04') {
 							agent { label 'buildtestmed' }
@@ -56,14 +76,22 @@ pipeline {
 									sudo docker build -t simplerisk/simplerisk:$current_version-focal -f simplerisk/focal/Dockerfile simplerisk/
 								"""
 							}
-						}
-					}
-					post {
-						failure {
-							node("terminator") {
-								terminateInstance("${instance_id}")
+							post {
+								success {
+									script {
+										if (env.CHANGE_ID) {
+											pullRequest.createStatus(status: "success", context: "build/simplerisk/ubuntu-2004", description: "Image built successfully", targetUrl: "$BUILD_URL")
+										}
+									}
+								}
+								failure {
+									terminateInstance("${instance_id}")
+									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}", "${committer_email}")
+								}
+								aborted {
+									terminateInstance("${instance_id}")
+								}
 							}
-							sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}", "${committer_email}")
 						}
 					}
 				}
@@ -77,10 +105,11 @@ pipeline {
 							}
 							post {
 								failure {
-									node("terminator") {
-										terminateInstance("${instance_id}")
-									}
+									terminateInstance("${instance_id}")
 									sendErrorEmail("${main_stage}/${env.STAGE_NAME}", "${committer_email}")
+								}
+								aborted {
+									terminateInstance("${instance_id}")
 								}
 							}
 						}
@@ -111,10 +140,11 @@ pipeline {
 							}
 							post {
 								failure {
-									node("terminator") {
-										terminateInstance("${instance_id}")
-									}
+									terminateInstance("${instance_id}")
 									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}", "${committer_email}")
+								}
+								aborted {
+									terminateInstance("${instance_id}")
 								}
 							}
 						}
@@ -122,10 +152,9 @@ pipeline {
 				}
 			}
 			post {
-				success {
-					node("terminator") {
-						terminateInstance("${instance_id}")
-					}
+				cleanup {
+					terminateInstance("${instance_id}")
+					sleep 60
 				}
 			}
 		}
@@ -141,7 +170,11 @@ pipeline {
 					}
 					post {
 						failure {
+							terminateInstance("${instance_id}")
 							sendErrorEmail("${main_stage}/${env.STAGE_NAME}", "${committer_email}")
+						}
+						aborted {
+							terminateInstance("${instance_id}")
 						}
 					}
 				}
@@ -159,6 +192,22 @@ pipeline {
 									sudo docker build -t simplerisk/simplerisk-minimal:$current_version-php72 -f simplerisk-minimal/php7.2/Dockerfile simplerisk-minimal/
 								"""
 							}
+							post {
+								success {
+									script {
+										if (env.CHANGE_ID) {
+											pullRequest.createStatus(status: "success", context: "build/simplerisk-minimal/php-72", description: "Image built successfully", targetUrl: "$BUILD_URL")
+										}
+									}
+								}
+								failure {
+									terminateInstance("${instance_id}")
+									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}", "${committer_email}")
+								}
+								aborted {
+									terminateInstance("${instance_id}")
+								}
+							}
 						}
 						stage ('PHP 7.4') {
 							agent { label 'buildtestmed' }
@@ -170,14 +219,22 @@ pipeline {
 									sudo docker build -t simplerisk/simplerisk-minimal:$current_version-php74 -f simplerisk-minimal/php7.4/Dockerfile simplerisk-minimal/
 								"""
 							}
-						}
-					}
-					post {
-						failure {
-							node("terminator") {
-								terminateInstance("${instance_id}")
+							post {
+								success {
+									script {
+										if (env.CHANGE_ID) {
+											pullRequest.createStatus(status: "success", context: "build/simplerisk-minimal/php-74", description: "Image built successfully", targetUrl: "$BUILD_URL")
+										}
+									}
+								}
+								failure {
+									terminateInstance("${instance_id}")
+									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}", "${committer_email}")
+								}
+								aborted {
+									terminateInstance("${instance_id}")
+								}
 							}
-							sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}", "${committer_email}")
 						}
 					}
 				}
@@ -191,10 +248,11 @@ pipeline {
 							}
 							post {
 								failure {
-									node("terminator") {
-										terminateInstance("${instance_id}")
-									}
+									terminateInstance("${instance_id}")
 									sendErrorEmail("${main_stage}/${env.STAGE_NAME}", "${committer_email}")
+								}
+								aborted {
+									terminateInstance("${instance_id}")
 								}
 							}
 						}
@@ -225,10 +283,11 @@ pipeline {
 							}
 							post {
 								failure {
-									node("terminator") {
-										terminateInstance("${instance_id}")
-									}
+									terminateInstance("${instance_id}")
 									sendErrorEmail("${main_stage}/${env.STAGE_NAME}/${image}")
+								}
+								aborted {
+									terminateInstance("${instance_id}")
 								}
 							}
 						}
@@ -236,10 +295,9 @@ pipeline {
 				}
 			}
 			post {
-				success {
-					node("terminator") {
-						terminateInstance("${instance_id}")
-					}
+				cleanup {
+					terminateInstance("${instance_id}")
+					sleep 60
 				}
 			}
 		}
@@ -289,6 +347,7 @@ void setDockerCreds() {
 }
 
 void terminateInstance(String instanceId, String region="us-east-1") {
-	sh "aws ec2 terminate-instances --instance-ids $instanceId --region $region"
-	sleep 60
+	node ("terminator") {
+		sh "aws ec2 terminate-instances --instance-ids $instanceId --region $region"
+	}
 }

--- a/generate_stack.sh
+++ b/generate_stack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/generate_stack.sh
+++ b/generate_stack.sh
@@ -29,7 +29,7 @@ services:
     command: mysqld --sql_mode="NO_ENGINE_SUBSTITUTION"
     environment:
     - MYSQL_ROOT_PASSWORD=$pass
-    image: mariadb:10.6
+    image: mariadb:10.7
 
   smtp:
     image: namshi/smtp

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -27,6 +27,8 @@ RUN apt-get update && \\
     apt-get -y install libldap2-dev \\
                        libcap2-bin \\
                        libcurl4-gnutls-dev \\
+                       libpng-dev \\
+                       libzip-dev \\
                        supervisor \\
                        cron \\
 EOF

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -41,7 +41,9 @@ RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu && \\
                            json \\
                            mysqli \\
                            pdo_mysql \\
-                           curl
+                           curl \\
+                           zip \\
+                           gd
 # Setting up setcap for port mapping without root and removing packages
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2 && \\
     chmod gu+s /usr/sbin/cron && \\
@@ -63,6 +65,7 @@ RUN service supervisor restart
 # Configure Apache
 RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini
 RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+RUN echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini
 RUN echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
 RUN echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
 # Create SSL Certificates for Apache SSL

--- a/simplerisk-minimal/php7.2/Dockerfile
+++ b/simplerisk-minimal/php7.2/Dockerfile
@@ -69,8 +69,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211010-001.tgz | tar xz -C /var/www && \
-    echo 20211010-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211027-001.tgz | tar xz -C /var/www && \
+    echo 20211027-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.2/Dockerfile
+++ b/simplerisk-minimal/php7.2/Dockerfile
@@ -66,8 +66,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210802-001.tgz | tar xz -C /var/www && \
-    echo 20210802-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210930-001.tgz | tar xz -C /var/www && \
+    echo 20210930-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.2/Dockerfile
+++ b/simplerisk-minimal/php7.2/Dockerfile
@@ -24,7 +24,9 @@ RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu && \
                            json \
                            mysqli \
                            pdo_mysql \
-                           curl
+                           curl \
+                           zip \
+                           gd
 # Setting up setcap for port mapping without root and removing packages
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2 && \
     chmod gu+s /usr/sbin/cron && \
@@ -46,6 +48,7 @@ RUN service supervisor restart
 # Configure Apache
 RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini
 RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+RUN echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini
 RUN echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
 RUN echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
 # Create SSL Certificates for Apache SSL

--- a/simplerisk-minimal/php7.2/Dockerfile
+++ b/simplerisk-minimal/php7.2/Dockerfile
@@ -71,8 +71,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211115-001.tgz | tar xz -C /var/www && \
-    echo 20211115-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211230-001.tgz | tar xz -C /var/www && \
+    echo 20211230-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.2/Dockerfile
+++ b/simplerisk-minimal/php7.2/Dockerfile
@@ -71,8 +71,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211230-001.tgz | tar xz -C /var/www && \
-    echo 20211230-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20220122-001.tgz | tar xz -C /var/www && \
+    echo 20220122-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.2/Dockerfile
+++ b/simplerisk-minimal/php7.2/Dockerfile
@@ -69,8 +69,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210930-001.tgz | tar xz -C /var/www && \
-    echo 20210930-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211010-001.tgz | tar xz -C /var/www && \
+    echo 20211010-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.2/Dockerfile
+++ b/simplerisk-minimal/php7.2/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
     apt-get -y install libldap2-dev \
                        libcap2-bin \
                        libcurl4-gnutls-dev \
+                       libpng-dev \
+                       libzip-dev \
                        supervisor \
                        cron \
                        mariadb-client && \

--- a/simplerisk-minimal/php7.2/Dockerfile
+++ b/simplerisk-minimal/php7.2/Dockerfile
@@ -69,8 +69,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211027-001.tgz | tar xz -C /var/www && \
-    echo 20211027-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211115-001.tgz | tar xz -C /var/www && \
+    echo 20211115-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -70,8 +70,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211010-001.tgz | tar xz -C /var/www && \
-    echo 20211010-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211027-001.tgz | tar xz -C /var/www && \
+    echo 20211027-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -25,7 +25,9 @@ RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu && \
                            json \
                            mysqli \
                            pdo_mysql \
-                           curl
+                           curl \
+                           zip \
+                           gd
 # Setting up setcap for port mapping without root and removing packages
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2 && \
     chmod gu+s /usr/sbin/cron && \
@@ -47,6 +49,7 @@ RUN service supervisor restart
 # Configure Apache
 RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini
 RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+RUN echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini
 RUN echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
 RUN echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
 # Create SSL Certificates for Apache SSL

--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -70,8 +70,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210930-001.tgz | tar xz -C /var/www && \
-    echo 20210930-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211010-001.tgz | tar xz -C /var/www && \
+    echo 20211010-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
     apt-get -y install libldap2-dev \
                        libcap2-bin \
                        libcurl4-gnutls-dev \
+                       libpng-dev \
+                       libzip-dev \
                        supervisor \
                        cron \
                        libonig-dev \

--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -70,8 +70,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211027-001.tgz | tar xz -C /var/www && \
-    echo 20211027-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211115-001.tgz | tar xz -C /var/www && \
+    echo 20211115-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -72,8 +72,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211230-001.tgz | tar xz -C /var/www && \
-    echo 20211230-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20220122-001.tgz | tar xz -C /var/www && \
+    echo 20220122-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -72,8 +72,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211115-001.tgz | tar xz -C /var/www && \
-    echo 20211115-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211230-001.tgz | tar xz -C /var/www && \
+    echo 20211230-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -67,8 +67,8 @@ RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabl
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210802-001.tgz | tar xz -C /var/www && \
-    echo 20210802-001 > /tmp/version
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210930-001.tgz | tar xz -C /var/www && \
+    echo 20210930-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20211230-001" > /tmp/version
+    echo "20220122-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211230-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211230-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20220122-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20220122-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -23,6 +23,8 @@ RUN dpkg-divert --local --rename /usr/bin/ischroot && \
                                                       php-ldap \
                                                       php7.2-mbstring \
                                                       php-curl \
+                                                      php-zip \
+                                                      php-gd \
                                                       nfs-common \
                                                       chrony \
                                                       cron \
@@ -54,6 +56,7 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.2/apache2/php.ini
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.2/apache2/php.ini
 RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.2/apache2/php.ini
+RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/7.2/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20211027-001" > /tmp/version
+    echo "20211115-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211027-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211027-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211115-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211115-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20211010-001" > /tmp/version
+    echo "20211027-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211010-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211010-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211027-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211027-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -56,7 +56,7 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.2/apache2/php.ini
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.2/apache2/php.ini
 RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.2/apache2/php.ini
-RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/7.2/apache2/php.ini
+RUN sed -i '/max_input_vars = 1000/a max_input_vars = 3000' /etc/php/7.2/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20210930-001" > /tmp/version
+    echo "20211010-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20210930-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210930-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211010-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211010-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -54,6 +54,7 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.2/apache2/php.ini
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.2/apache2/php.ini
 RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.2/apache2/php.ini
+RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/7.2/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20211115-001" > /tmp/version
+    echo "20211230-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211115-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211115-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211230-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211230-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -54,7 +54,6 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.2/apache2/php.ini
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.2/apache2/php.ini
 RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.2/apache2/php.ini
-RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/7.2/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt
@@ -76,12 +75,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20210802-001" > /tmp/version
+    echo "20210930-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20210802-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210802-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20210930-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210930-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/common/entrypoint.sh
+++ b/simplerisk/common/entrypoint.sh
@@ -19,15 +19,21 @@ set_db_password(){
 }
 
 set_config(){
-	CONFIG_PATH='/var/www/simplerisk/includes/config.php'
+	# If the config.php hasn't already been configured
+	if [ ! -f /configurations/simplerisk-config-configured ]; then
+		CONFIG_PATH='/var/www/simplerisk/includes/config.php'
 
-	SIMPLERISK_DB_HOSTNAME=localhost && sed -i "s/\('DB_HOSTNAME', '\).*\(');\)/\1$SIMPLERISK_DB_HOSTNAME\2/g" $CONFIG_PATH
-	SIMPLERISK_DB_PORT=3306 && sed -i "s/\('DB_PORT', '\).*\(');\)/\1$SIMPLERISK_DB_PORT\2/g" $CONFIG_PATH
-	SIMPLERISK_DB_USERNAME=simplerisk && sed -i "s/\('DB_USERNAME', '\).*\(');\)/\1$SIMPLERISK_DB_USERNAME\2/g" $CONFIG_PATH
-	set_db_password
-	SIMPLERISK_DB_DATABASE=simplerisk && sed -i "s/\('DB_DATABASE', '\).*\(');\)/\1$SIMPLERISK_DB_DATABASE\2/g" $CONFIG_PATH
-	# shellcheck disable=SC2015
-	[ "$(cat /tmp/version)" == "testing" ] && sed -i "s|//\(define('.*_URL\)|\1|g" $CONFIG_PATH || true
+		SIMPLERISK_DB_HOSTNAME=localhost && sed -i "s/\('DB_HOSTNAME', '\).*\(');\)/\1$SIMPLERISK_DB_HOSTNAME\2/g" $CONFIG_PATH
+		SIMPLERISK_DB_PORT=3306 && sed -i "s/\('DB_PORT', '\).*\(');\)/\1$SIMPLERISK_DB_PORT\2/g" $CONFIG_PATH
+		SIMPLERISK_DB_USERNAME=simplerisk && sed -i "s/\('DB_USERNAME', '\).*\(');\)/\1$SIMPLERISK_DB_USERNAME\2/g" $CONFIG_PATH
+		set_db_password
+		SIMPLERISK_DB_DATABASE=simplerisk && sed -i "s/\('DB_DATABASE', '\).*\(');\)/\1$SIMPLERISK_DB_DATABASE\2/g" $CONFIG_PATH
+		# shellcheck disable=SC2015
+		[ "$(cat /tmp/version)" == "testing" ] && sed -i "s|//\(define('.*_URL\)|\1|g" $CONFIG_PATH || true
+	
+		# Create a file so this doesn't run again
+		touch /configurations/simplerisk-config-configured
+	fi
 }
 
 configure_db() {

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20211230-001" > /tmp/version
+    echo "20220122-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211230-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211230-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20220122-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20220122-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20211027-001" > /tmp/version
+    echo "20211115-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211027-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211027-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211115-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211115-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20210930-001" > /tmp/version
+    echo "20211010-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20210930-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210930-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211010-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211010-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -54,7 +54,6 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.4/apache2/php.ini
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.4/apache2/php.ini
 RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.4/apache2/php.ini
-RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/7.4/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt
@@ -76,12 +75,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20210802-001" > /tmp/version
+    echo "20210930-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20210802-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210802-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20210930-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20210930-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20211010-001" > /tmp/version
+    echo "20211027-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211010-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211010-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211027-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211027-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -23,6 +23,8 @@ RUN dpkg-divert --local --rename /usr/bin/ischroot && \
                                                       php-ldap \
                                                       php7.4-mbstring \
                                                       php-curl \
+                                                      php-zip \
+                                                      php-gd \
                                                       nfs-common \
                                                       chrony \
                                                       cron \
@@ -54,6 +56,7 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.4/apache2/php.ini
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.4/apache2/php.ini
 RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.4/apache2/php.ini
+RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/7.4/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -54,6 +54,7 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.4/apache2/php.ini
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.4/apache2/php.ini
 RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.4/apache2/php.ini
+RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/7.4/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -56,7 +56,7 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.4/apache2/php.ini
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.4/apache2/php.ini
 RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.4/apache2/php.ini
-RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/7.4/apache2/php.ini
+RUN sed -i '/max_input_vars = 1000/a max_input_vars = 3000' /etc/php/7.4/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -78,12 +78,12 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
-    echo "20211115-001" > /tmp/version
+    echo "20211230-001" > /tmp/version
 
 # Download SimpleRisk
 RUN rm -rf /var/www/html && \
-    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211115-001.sql > /simplerisk.sql && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211115-001.tgz | tar xz -C /var/www
+    curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-20211230-001.sql > /simplerisk.sql && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-20211230-001.tgz | tar xz -C /var/www
 
 # Permissions
 RUN chown -R www-data: /var/www/simplerisk

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -39,6 +39,8 @@ RUN dpkg-divert --local --rename /usr/bin/ischroot && \\
                                                       php-ldap \\
                                                       php$php_version-mbstring \\
                                                       php-curl \\
+                                                      php-zip \\
+                                                      php-gd \\
                                                       nfs-common \\
                                                       chrony \\
                                                       cron \\
@@ -70,6 +72,7 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/$php_version/apache2/php.ini
 RUN sed -i 's/\\(upload_max_filesize =\\) .*\\(M\\)/\\1 5\\2/g' /etc/php/$php_version/apache2/php.ini
 RUN sed -i 's/\\(memory_limit =\\) .*\\(M\\)/\\1 256\\2/g' /etc/php/$php_version/apache2/php.ini
+RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/$php_version/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -72,7 +72,7 @@ COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/$php_version/apache2/php.ini
 RUN sed -i 's/\\(upload_max_filesize =\\) .*\\(M\\)/\\1 5\\2/g' /etc/php/$php_version/apache2/php.ini
 RUN sed -i 's/\\(memory_limit =\\) .*\\(M\\)/\\1 256\\2/g' /etc/php/$php_version/apache2/php.ini
-RUN sed -i 's/; max_input_vars = 1000/max_input_vars = 3000/g' /etc/php/$php_version/apache2/php.ini
+RUN sed -i '/max_input_vars = 1000/a max_input_vars = 3000' /etc/php/$php_version/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt

--- a/stack.yml
+++ b/stack.yml
@@ -6,9 +6,9 @@ services:
   simplerisk:
     environment:
     - FIRST_TIME_SETUP=1
-    - FIRST_TIME_SETUP_PASS=n3ZANCHSvrWxGd7DsVXU4
+    - FIRST_TIME_SETUP_PASS=_IGCIU1dVZWjUqgSnTZgc
     - SIMPLERISK_DB_HOSTNAME=mariadb
-    image: simplerisk/simplerisk-minimal:20210802-001
+    image: simplerisk/simplerisk-minimal:20220122-001
     ports:
     - "80:80"
     - "443:443"
@@ -16,8 +16,8 @@ services:
   mariadb:
     command: mysqld --sql_mode="NO_ENGINE_SUBSTITUTION"
     environment:
-    - MYSQL_ROOT_PASSWORD=n3ZANCHSvrWxGd7DsVXU4
-    image: mariadb:10.6
+    - MYSQL_ROOT_PASSWORD=_IGCIU1dVZWjUqgSnTZgc
+    image: mariadb:10.7
 
   smtp:
     image: namshi/smtp

--- a/stack.yml
+++ b/stack.yml
@@ -6,9 +6,9 @@ services:
   simplerisk:
     environment:
     - FIRST_TIME_SETUP=1
-    - FIRST_TIME_SETUP_PASS=_cgQW5oFAKGqo604btIVW
+    - FIRST_TIME_SETUP_PASS=n3ZANCHSvrWxGd7DsVXU4
     - SIMPLERISK_DB_HOSTNAME=mariadb
-    image: simplerisk/simplerisk-minimal:20210713-001
+    image: simplerisk/simplerisk-minimal:20210802-001
     ports:
     - "80:80"
     - "443:443"
@@ -16,7 +16,7 @@ services:
   mariadb:
     command: mysqld --sql_mode="NO_ENGINE_SUBSTITUTION"
     environment:
-    - MYSQL_ROOT_PASSWORD=_cgQW5oFAKGqo604btIVW
+    - MYSQL_ROOT_PASSWORD=n3ZANCHSvrWxGd7DsVXU4
     image: mariadb:10.6
 
   smtp:


### PR DESCRIPTION
- Updating stack to use the newest version of SimpleRisk, plus updating MariaDB version
- Updating scripts to use a portable way to call bash (`/usr/bin/env bash` instead of `/bin/bash`)
- Workflow tested for Spot Instance usage
- Using specific instance for agent termination
- Using Ubuntu 20.04/PHP 7.4 as main versions, as Ubuntu 18.04/PHP 7.2 are soon to be deprecated.