### PR TITLE
Minimal PHP 7.4 - Add required libs

### DIFF
--- a/simplerisk-minimal/php7.4/Dockerfile
+++ b/simplerisk-minimal/php7.4/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
     apt-get -y install libldap2-dev \
                        libcap2-bin \
                        libcurl4-gnutls-dev \
+                       libpng-dev \
+                       libzip-dev \
                        supervisor \
                        cron \
                        libonig-dev \


### PR DESCRIPTION
The minimal dockerfile was failing on the "Configure all PHP extensions" step because of thse missing libraries. 

It's possible that the same libraries would be required for PHP7.2 but I did not attempt to build that image. 