### PR TITLE
Allow the usage of new installer on `simplerisk-minimal`

### DIFF
--- a/simplerisk-minimal/README.md
+++ b/simplerisk-minimal/README.md
@@ -31,12 +31,21 @@ docker run --name simplerisk -e SIMPLERISK_DB_HOST=db-server.example.com -p 80:8
 
 ### Set up database (Optional)
 
-If this is the first time running the application, the MySQL/MariaDB database needs to be set up with the SimpleRisk schema. For this, please provide the environment variable `FIRST_TIME_SETUP` and optionally provide any of the variables that start with `FIRST_TIME_SETUP_*` to customize the set up.
+If this is the first time running the application, the MySQL/MariaDB database needs to be set up with the SimpleRisk schema. You have two options to set it up:
+
+#### New Installer (GUI)
+
+Since the `20220306-001` release, SimpleRisk now offers a graphical installation method. Just run the SimpleRisk container without any environment variables (remember to specify the 80/443 ports), then access it. From there, you can specify the location of the database, create and customize the database settings and create a new administrator user.
+
+#### Docker Setup (CLI)
+
+You must provide the environment variable `FIRST_TIME_SETUP` and optionally provide any of the variables from the **Environment variables** section that start with `FIRST_TIME_SETUP_*` to customize the setup.
 
 To only set up the database and discard the container afterwards, use the `FIRST_TIME_SETUP_ONLY` variable. This might be helpful in a situation where you only want to configure the database (like a initContainer on Kubernetes) and, if the process ran successfully, execute a new container with SimpleRisk running normally.
 
 Another detail to consider is that if the database set up is being executed and the `SIMPLERISK_DB_PASSWORD` variable is not provided, the application will generate a random password and show it on the container logs.
 
+The default user created is `admin/admin`.
 
 ## Environment variables
 

--- a/simplerisk-minimal/common/entrypoint.sh
+++ b/simplerisk-minimal/common/entrypoint.sh
@@ -53,8 +53,8 @@ set_config(){
     # shellcheck disable=SC2015
     [ -n "${SIMPLERISK_DB_SSL_CERT_PATH:-}" ] && sed -i "s/\('DB_SSL_CERTIFICATE_PATH', '\).*\(');\)/\1$SIMPLERISK_DB_SSL_CERT_PATH\2/g" $CONFIG_PATH || true
 
-    # Update the SIMPLERISK_INSTALLED value
-    exec_cmd "sed -i \"s/\('SIMPLERISK_INSTALLED', 'false'\)/'SIMPLERISK_INSTALLED', 'true'/g\" $CONFIG_PATH"
+    # If testing is enabled, update the SIMPLERISK_INSTALLED value
+    [ "$(cat /tmp/version)" == "testing" ] && exec_cmd "sed -i \"s/\('SIMPLERISK_INSTALLED', \)'true'/\1'false'/g\" $CONFIG_PATH" || true
 
     # shellcheck disable=SC2015
     [ "$(cat /tmp/version)" == "testing" ] && exec_cmd "sed -i \"s|//\(define('.*_URL\)|\1|g\" $CONFIG_PATH" || true
@@ -91,6 +91,9 @@ EOSQL" "Was not able to apply settings on database. Check error above. Exiting."
     print_log "initial_setup:info" "Setup has been applied successfully!"
     print_log "initial_setup:info" "Removing schema file..."
     exec_cmd "rm ${SCHEMA_FILE}"
+
+    # Update the SIMPLERISK_INSTALLED value
+    exec_cmd "sed -i \"s/\('SIMPLERISK_INSTALLED', \)'false'/\1'true'/g\" $CONFIG_PATH"
 
     # shellcheck disable=SC2015
     [ -n "${FIRST_TIME_SETUP_ONLY:-}" ] && print_log "initial_setup:info" "Running on setup only. Container will be discarded." && exit 0 || true


### PR DESCRIPTION
These changes will allow the user to run the new installer.