### PR TITLE
Fix for missing mysql homedir.

### DIFF
--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -46,6 +46,7 @@ RUN service supervisor restart
 
 # Configure MySQL
 RUN sed -i 's/\[mysqld\]/\[mysqld\]\nsql-mode="NO_ENGINE_SUBSTITUTION"/g' /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN usermod -d /var/lib/mysql/ mysql
 
 # Configure Apache
 COPY common/foreground.sh /etc/apache2/foreground.sh


### PR DESCRIPTION
Fixes #37 

Attempting to start docker container after first run will crash the container.  The fix is to set the homedir for the mysql user.

