### PR TITLE
FIX: MySQL/Apache handling through supervisord

### DIFF
--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -54,37 +54,33 @@ RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2 && \\
     apt-get -y purge
 
 # Copying all files
-COPY common/supervisord.conf /etc/supervisord.conf
 COPY common/foreground.sh /etc/apache2/foreground.sh
 COPY common/envvars /etc/apache2/envvars
 COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 COPY common/entrypoint.sh /entrypoint.sh
 
-# Start supervisor 
-RUN service supervisor restart
-
 # Configure Apache
-RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini
-RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
-RUN echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini
-RUN echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
-RUN echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
+RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini && \\
+	echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini && \\
+	echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini && \\
+	echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini && \\
+	echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini && \\
 # Create SSL Certificates for Apache SSL
-RUN echo \$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c\${1:-32}) > /tmp/pass_openssl.txt
-RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key
-RUN openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
-RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key /tmp/pass_openssl.txt
-RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
-RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
+	echo \$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c\${1:-32}) > /tmp/pass_openssl.txt && \\
+	mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \\
+	openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \\
+	openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key && \\
+	rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key /tmp/pass_openssl.txt && \\
+	openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk" && \\
+	openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt && \\
 # Activate Apache modules
-RUN a2enmod rewrite ssl
-RUN a2enconf security
-RUN sed -i 's/SSLProtocol all -SSLv3/SSLProtocol TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
-RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
+	a2enmod rewrite ssl && \\
+	a2enconf security && \\
+	sed -i 's/\\(SSLProtocol\\) all -SSLv3/\1 TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf && \\
+	sed -i 's/#\\(SSLHonorCipherOrder on\\)/\\1/g' /etc/apache2/mods-enabled/ssl.conf && \\
+	sed -i 's/\\(ServerTokens\\) OS/\\1 Prod/g' /etc/apache2/conf-enabled/security.conf && \\
+	sed -i 's/#\\(ServerSignature\\) On/\\1 Off/g' /etc/apache2/conf-enabled/security.conf
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \\
@@ -102,20 +98,17 @@ fi
 cat << EOF >> "php$image_dir/Dockerfile"
 
 # Creating Simplerisk user on www-data group and setting up ownerships
-RUN useradd -G www-data simplerisk
-RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \\
-    chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \\
-    chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
-
+RUN useradd -G www-data simplerisk && \\
+	chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \\
+	chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \\
+	chmod 755 /entrypoint.sh /etc/apache2/foreground.sh && \\
 # Setting up cronjob
-RUN echo "* * * * * /usr/local/bin/php -f /var/www/simplerisk/cron/cron.php > /dev/null 2>&1" >> /etc/cron.d/backup-cron && \\
-    chmod 0644 /etc/cron.d/backup-cron && \\
-    crontab /etc/cron.d/backup-cron
+	echo "* * * * * /usr/local/bin/php -f /var/www/simplerisk/cron/cron.php > /dev/null 2>&1" >> /etc/cron.d/backup-cron && \\
+	chmod 0644 /etc/cron.d/backup-cron && \\
+	crontab /etc/cron.d/backup-cron
 
 # Data to save
-VOLUME /var/log/apache2
-VOLUME /etc/apache2/ssl
-VOLUME /var/www/simplerisk
+VOLUME [ "/var/log/apache2", "/etc/apache2/ssl", "/var/www/simplerisk" ]
 
 # Using simplerisk user from here
 USER simplerisk

--- a/simplerisk-minimal/php72/Dockerfile
+++ b/simplerisk-minimal/php72/Dockerfile
@@ -36,37 +36,33 @@ RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2 && \
     apt-get -y purge
 
 # Copying all files
-COPY common/supervisord.conf /etc/supervisord.conf
 COPY common/foreground.sh /etc/apache2/foreground.sh
 COPY common/envvars /etc/apache2/envvars
 COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 COPY common/entrypoint.sh /entrypoint.sh
 
-# Start supervisor 
-RUN service supervisor restart
-
 # Configure Apache
-RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini
-RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
-RUN echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini
-RUN echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
-RUN echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
+RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini && \
+	echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini && \
+	echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini && \
+	echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini && \
+	echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini && \
 # Create SSL Certificates for Apache SSL
-RUN echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32}) > /tmp/pass_openssl.txt
-RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key
-RUN openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
-RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key /tmp/pass_openssl.txt
-RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
-RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
+	echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32}) > /tmp/pass_openssl.txt && \
+	mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \
+	openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \
+	openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key && \
+	rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key /tmp/pass_openssl.txt && \
+	openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk" && \
+	openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt && \
 # Activate Apache modules
-RUN a2enmod rewrite ssl
-RUN a2enconf security
-RUN sed -i 's/SSLProtocol all -SSLv3/SSLProtocol TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
-RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
+	a2enmod rewrite ssl && \
+	a2enconf security && \
+	sed -i 's/\(SSLProtocol\) all -SSLv3/\1 TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf && \
+	sed -i 's/#\(SSLHonorCipherOrder on\)/\1/g' /etc/apache2/mods-enabled/ssl.conf && \
+	sed -i 's/\(ServerTokens\) OS/\1 Prod/g' /etc/apache2/conf-enabled/security.conf && \
+	sed -i 's/#\(ServerSignature\) On/\1 Off/g' /etc/apache2/conf-enabled/security.conf
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
@@ -74,20 +70,17 @@ RUN rm -rf /var/www/html && \
     echo 20220701-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
-RUN useradd -G www-data simplerisk
-RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
-    chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
-    chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
-
+RUN useradd -G www-data simplerisk && \
+	chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+	chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+	chmod 755 /entrypoint.sh /etc/apache2/foreground.sh && \
 # Setting up cronjob
-RUN echo "* * * * * /usr/local/bin/php -f /var/www/simplerisk/cron/cron.php > /dev/null 2>&1" >> /etc/cron.d/backup-cron && \
-    chmod 0644 /etc/cron.d/backup-cron && \
-    crontab /etc/cron.d/backup-cron
+	echo "* * * * * /usr/local/bin/php -f /var/www/simplerisk/cron/cron.php > /dev/null 2>&1" >> /etc/cron.d/backup-cron && \
+	chmod 0644 /etc/cron.d/backup-cron && \
+	crontab /etc/cron.d/backup-cron
 
 # Data to save
-VOLUME /var/log/apache2
-VOLUME /etc/apache2/ssl
-VOLUME /var/www/simplerisk
+VOLUME [ "/var/log/apache2", "/etc/apache2/ssl", "/var/www/simplerisk" ]
 
 # Using simplerisk user from here
 USER simplerisk

--- a/simplerisk-minimal/php74/Dockerfile
+++ b/simplerisk-minimal/php74/Dockerfile
@@ -37,37 +37,33 @@ RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2 && \
     apt-get -y purge
 
 # Copying all files
-COPY common/supervisord.conf /etc/supervisord.conf
 COPY common/foreground.sh /etc/apache2/foreground.sh
 COPY common/envvars /etc/apache2/envvars
 COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 COPY common/entrypoint.sh /entrypoint.sh
 
-# Start supervisor 
-RUN service supervisor restart
-
 # Configure Apache
-RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini
-RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
-RUN echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini
-RUN echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
-RUN echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini
+RUN echo 'upload_max_filesize = 5M' >> /usr/local/etc/php/conf.d/docker-php-uploadfilesize.ini && \
+	echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini && \
+	echo 'max_input_vars = 3000' >> /usr/local/etc/php/conf.d/docker-php-maxinputvars.ini && \
+	echo 'log_errors = On' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini && \
+	echo 'error_log = /dev/stderr' >> /usr/local/etc/php/conf.d/docker-php-error_logging.ini && \
 # Create SSL Certificates for Apache SSL
-RUN echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32}) > /tmp/pass_openssl.txt
-RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key
-RUN openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
-RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key /tmp/pass_openssl.txt
-RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
-RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
+	echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32}) > /tmp/pass_openssl.txt && \
+	mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \
+	openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \
+	openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key && \
+	rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key /tmp/pass_openssl.txt && \
+	openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk" && \
+	openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt && \
 # Activate Apache modules
-RUN a2enmod rewrite ssl
-RUN a2enconf security
-RUN sed -i 's/SSLProtocol all -SSLv3/SSLProtocol TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
-RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
+	a2enmod rewrite ssl && \
+	a2enconf security && \
+	sed -i 's/\(SSLProtocol\) all -SSLv3/\1 TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf && \
+	sed -i 's/#\(SSLHonorCipherOrder on\)/\1/g' /etc/apache2/mods-enabled/ssl.conf && \
+	sed -i 's/\(ServerTokens\) OS/\1 Prod/g' /etc/apache2/conf-enabled/security.conf && \
+	sed -i 's/#\(ServerSignature\) On/\1 Off/g' /etc/apache2/conf-enabled/security.conf
 
 # Download and extract SimpleRisk, plus saving release version for database reference
 RUN rm -rf /var/www/html && \
@@ -75,20 +71,17 @@ RUN rm -rf /var/www/html && \
     echo 20220701-001 > /tmp/version
 
 # Creating Simplerisk user on www-data group and setting up ownerships
-RUN useradd -G www-data simplerisk
-RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
-    chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
-    chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
-
+RUN useradd -G www-data simplerisk && \
+	chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+	chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+	chmod 755 /entrypoint.sh /etc/apache2/foreground.sh && \
 # Setting up cronjob
-RUN echo "* * * * * /usr/local/bin/php -f /var/www/simplerisk/cron/cron.php > /dev/null 2>&1" >> /etc/cron.d/backup-cron && \
-    chmod 0644 /etc/cron.d/backup-cron && \
-    crontab /etc/cron.d/backup-cron
+	echo "* * * * * /usr/local/bin/php -f /var/www/simplerisk/cron/cron.php > /dev/null 2>&1" >> /etc/cron.d/backup-cron && \
+	chmod 0644 /etc/cron.d/backup-cron && \
+	crontab /etc/cron.d/backup-cron
 
 # Data to save
-VOLUME /var/log/apache2
-VOLUME /etc/apache2/ssl
-VOLUME /var/www/simplerisk
+VOLUME [ "/var/log/apache2", "/etc/apache2/ssl", "/var/www/simplerisk" ]
 
 # Using simplerisk user from here
 USER simplerisk

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -7,7 +7,13 @@ FROM ubuntu:bionic
 LABEL maintainer="Simplerisk <support@simplerisk.com>"
 
 # Make necessary directories
-RUN mkdir -p /configurations /etc/apache2/ssl /passwords /var/{log,lib/mysql,www/simplerisk}
+RUN mkdir -p /configurations \
+	     /etc/apache2/ssl \
+	     /passwords \
+	     /var/log/supervisor \
+	     /var/lib/mysql \
+	     /var/run/supervisor \
+	     /var/www/simplerisk
                                                                     
 # Installing apt dependencies     
 RUN dpkg-divert --local --rename /usr/bin/ischroot && \
@@ -40,42 +46,37 @@ RUN dpkg-divert --local --rename /usr/bin/ischroot && \
 RUN < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c21 > /passwords/pass_openssl.txt
 
 # Install and configure supervisor
-COPY common/supervisord.conf /etc/supervisord.conf
-#RUN mkdir /var/log/supervisor/
-RUN service supervisor restart
+COPY common/supervisord.conf /etc/supervisor/supervisord.conf
 
 # Configure MySQL
 RUN sed -i 's/\[mysqld\]/\[mysqld\]\nsql-mode="NO_ENGINE_SUBSTITUTION"/g' /etc/mysql/mysql.conf.d/mysqld.cnf
 
 # Configure Apache
 COPY common/foreground.sh /etc/apache2/foreground.sh
-RUN chmod 755 /etc/apache2/foreground.sh
 COPY common/envvars /etc/apache2/envvars
 COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
-RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.2/apache2/php.ini
-RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.2/apache2/php.ini
-RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.2/apache2/php.ini
-RUN sed -i '/max_input_vars = 1000/a max_input_vars = 3000' /etc/php/7.2/apache2/php.ini
+RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.2/apache2/php.ini && \
+	sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.2/apache2/php.ini && \
+	sed -i 's/;\(max_input_vars =\) .*/\1 3000/g' /etc/php/7.2/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
-RUN mkdir -p /etc/apache2/ssl/ssl.crt
-RUN mkdir -p /etc/apache2/ssl/ssl.key
-RUN openssl genrsa -des3 -passout pass:/passwords/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl rsa -passin pass:/passwords/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
-RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
-RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
+RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \
+	openssl genrsa -des3 -passout pass:/passwords/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \
+	openssl rsa -passin pass:/passwords/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key && \
+	rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \
+	openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk" && \
+	openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
 
 # Activate Apache modules
-RUN phpenmod ldap
-RUN a2enmod rewrite
-RUN a2enmod ssl
-RUN a2enconf security
-RUN sed -i 's/SSLProtocol all -SSLv3/SSLProtocol TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
-RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
+RUN phpenmod ldap && \
+	a2enmod rewrite && \
+	a2enmod ssl && \
+	a2enconf security && \
+	sed -i 's/\(SSLProtocol\) all -SSLv3/\1 TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf && \
+	sed -i 's/#\(SSLHonorCipherOrder on\)/\1/g' /etc/apache2/mods-enabled/ssl.conf && \
+	sed -i 's/\(ServerTokens\) OS/\1 Prod/g' /etc/apache2/conf-enabled/security.conf && \
+	sed -i 's/\(ServerSignature\) On/\1 Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
     echo "20220701-001" > /tmp/version
@@ -98,18 +99,13 @@ EXPOSE 443
 
 # Create the start script and set permissions
 COPY common/entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+RUN chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
 
 # Data to save
-VOLUME /passwords
-VOLUME /configurations
-VOLUME /var/log
-VOLUME /var/lib/mysql
-VOLUME /etc/apache2/ssl
-VOLUME /var/www/simplerisk
+VOLUME [ "/passwords", "/configurations", "/var/log", "/var/lib/mysql", "/etc/apache2/ssl", "/var/www/simplerisk" ]
 
 # Setting up entrypoint
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 # Start Apache and MySQL
-CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
+CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]

--- a/simplerisk/bionic/Dockerfile
+++ b/simplerisk/bionic/Dockerfile
@@ -58,7 +58,7 @@ COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.2/apache2/php.ini && \
 	sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.2/apache2/php.ini && \
-	sed -i 's/;\(max_input_vars =\) .*/\1 3000/g' /etc/php/7.2/apache2/php.ini
+	sed -i 's/;.*\(max_input_vars =\) .*/\1 3000/g' /etc/php/7.2/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \

--- a/simplerisk/common/entrypoint.sh
+++ b/simplerisk/common/entrypoint.sh
@@ -50,12 +50,11 @@ set_config(){
 }
 
 configure_db() {
-	# Start MySQL and wait 10 seconds
-	/etc/init.d/mysql start && sleep 10s
-
 	# If MySQL hasn't already been configured
 	if [ ! -f /configurations/mysql-configured ]; then
+		# Start MySQL and wait 10 seconds for the startup
 		print_log "initial_setup:mysql" "Setting up MySQL"
+		service mysql start && sleep 10s
 
 		local password
 		password="$(cat /passwords/pass_mysql_root.txt)"
@@ -80,8 +79,9 @@ configure_db() {
 		touch /configurations/mysql-configured
 
 		print_log "initial_setup:mysql" "MySQL set properly"
+		service mysql stop
+		service mysql status || true
 	fi
-
 }
 
 unset_variables() {

--- a/simplerisk/common/entrypoint.sh
+++ b/simplerisk/common/entrypoint.sh
@@ -80,7 +80,6 @@ configure_db() {
 
 		print_log "initial_setup:mysql" "MySQL set properly"
 		service mysql stop
-		service mysql status || true
 	fi
 }
 

--- a/simplerisk/common/entrypoint.sh
+++ b/simplerisk/common/entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+print_log(){
+    echo "$(date -u +"[%a %b %e %X.%6N %Y]") [$1] $2"
+}
+
 generate_random_password() {
 	echo "$(< /dev/urandom tr -dc A-Za-z0-9 | head -c21)"
 }
@@ -21,6 +25,8 @@ set_db_password(){
 set_config(){
 	# If the config.php hasn't already been configured
 	if [ ! -f /configurations/simplerisk-config-configured ]; then
+		print_log "initial_setup:config" "Setting up SimpleRisk's configuration"
+
 		CONFIG_PATH='/var/www/simplerisk/includes/config.php'
 
 		# TEMP: localhost as hostname is not working on Ubuntu 20.04
@@ -38,6 +44,8 @@ set_config(){
 	
 		# Create a file so this doesn't run again
 		touch /configurations/simplerisk-config-configured
+
+		print_log "initial_setup:config" "SimpleRisk's configuration file set properly"
 	fi
 }
 
@@ -47,6 +55,8 @@ configure_db() {
 
 	# If MySQL hasn't already been configured
 	if [ ! -f /configurations/mysql-configured ]; then
+		print_log "initial_setup:mysql" "Setting up MySQL"
+
 		local password
 		password="$(cat /passwords/pass_mysql_root.txt)"
 		# Set the MySQL root password
@@ -68,6 +78,8 @@ configure_db() {
 
 		# Create a file so this doesn't run again
 		touch /configurations/mysql-configured
+
+		print_log "initial_setup:mysql" "MySQL set properly"
 	fi
 
 }
@@ -80,10 +92,14 @@ unset_variables() {
 }
 
 _main() {
+	print_log "startup:general" "Starting SimpleRisk container..."
+
 	set_config
 	configure_db
 	unset_variables
 	service cron start
+
+	print_log "startup:general" "Container startup is finished"
 	exec "$@"
 }
 

--- a/simplerisk/common/supervisord.conf
+++ b/simplerisk/common/supervisord.conf
@@ -1,151 +1,26 @@
-; Sample supervisor config file.
-;
-; For more information on the config file, please see:
-; http://supervisord.org/configuration.html
-;
-; Note: shell expansion ("~" or "$HOME") is not supported.  Environment
-; variables can be expanded using this syntax: "%(ENV_HOME)s".
-
 [unix_http_server]
-file=/tmp/supervisor.sock   ; (the path to the socket file)
-;chmod=0700                 ; socket file mode (default 0700)
-;chown=nobody:nogroup       ; socket file uid:gid owner
-;username=user              ; (default is no username (open server))
-;password=123               ; (default is no password (open server))
-
-;[inet_http_server]         ; inet (TCP) server disabled by default
-;port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
-;username=user              ; (default is no username (open server))
-;password=123               ; (default is no password (open server))
+file=/tmp/supervisor.sock                   ; (the path to the socket file)
+chmod=0700
 
 [supervisord]
-logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)
-logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
-logfile_backups=10           ; (num of main logfile rotation backups;default 10)
-loglevel=info                ; (log level;default info; others: debug,warn,trace)
-pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-nodaemon=false               ; (start in foreground if true;default false)
-minfds=1024                  ; (min. avail startup file descriptors;default 1024)
-minprocs=200                 ; (min. avail process descriptors;default 200)
-;umask=022                   ; (process file creation umask;default 022)
-;user=chrism                 ; (default is current user, required if root)
-;identifier=supervisor       ; (supervisord identifier, default is 'supervisor')
-;directory=/tmp              ; (default is not to cd during start)
-;nocleanup=true              ; (don't clean up tempfiles at start;default false)
-;childlogdir=/tmp            ; ('AUTO' child log dir, default $TEMP)
-;environment=KEY=value       ; (key value pairs to add to environment)
-;strip_ansi=false            ; (strip ansi escape codes in logs; def. false)
+childlogdir=/var/log/supervisor
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile_maxbytes=50MB                       ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_backups=10                          ; (num of main logfile rotation backups;default 10)
+loglevel=info                               ; (log level;default info; others: debug,warn,trace)
+pidfile=/var/run/supervisor/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+nodaemon=false                              ; (start in foreground if true;default false)
+minfds=1024                                 ; (min. avail startup file descriptors;default 1024)
+minprocs=200                                ; (min. avail process descriptors;default 200)
 
-; the below section must remain in the config file for RPC
-; (supervisorctl/web interface) to work, additional interfaces may be
-; added by defining them in separate rpcinterface: sections
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
 serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
-;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
-;username=chris              ; should be same as http_username if set
-;password=123                ; should be same as http_password if set
-;prompt=mysupervisor         ; cmd line prompt (default "supervisor")
-;history_file=~/.sc_history  ; use readline history if available
 
-; The below sample program section shows all possible program subsection values,
-; create one or more 'real' program: sections to be able to control them under
-; supervisor.
-
-;[program:theprogramname]
-;command=/bin/cat              ; the program (relative uses PATH, can take args)
-;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
-;numprocs=1                    ; number of processes copies to start (def 1)
-;directory=/tmp                ; directory to cwd to before exec (def no cwd)
-;umask=022                     ; umask for process (default None)
-;priority=999                  ; the relative start priority (default 999)
-;autostart=true                ; start at supervisord start (default: true)
-;autorestart=unexpected        ; whether/when to restart (default: unexpected)
-;startsecs=1                   ; number of secs prog must stay running (def. 1)
-;startretries=3                ; max # of serial start failures (default 3)
-;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
-;stopsignal=QUIT               ; signal used to kill process (default TERM)
-;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
-;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
-;killasgroup=false             ; SIGKILL the UNIX process group (def false)
-;user=chrism                   ; setuid to this UNIX account to run the program
-;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
-;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
-;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
-;stdout_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
-;stdout_events_enabled=false   ; emit events on stdout writes (default false)
-;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
-;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
-;stderr_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
-;stderr_events_enabled=false   ; emit events on stderr writes (default false)
-;environment=A=1,B=2           ; process environment additions (def no adds)
-;serverurl=AUTO                ; override serverurl computation (childutils)
-
-; The below sample eventlistener section shows all possible
-; eventlistener subsection values, create one or more 'real'
-; eventlistener: sections to be able to handle event notifications
-; sent by supervisor.
-
-;[eventlistener:theeventlistenername]
-;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)
-;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
-;numprocs=1                    ; number of processes copies to start (def 1)
-;events=EVENT                  ; event notif. types to subscribe to (req'd)
-;buffer_size=10                ; event buffer queue size (default 10)
-;directory=/tmp                ; directory to cwd to before exec (def no cwd)
-;umask=022                     ; umask for process (default None)
-;priority=-1                   ; the relative start priority (default -1)
-;autostart=true                ; start at supervisord start (default: true)
-;autorestart=unexpected        ; whether/when to restart (default: unexpected)
-;startsecs=1                   ; number of secs prog must stay running (def. 1)
-;startretries=3                ; max # of serial start failures (default 3)
-;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
-;stopsignal=QUIT               ; signal used to kill process (default TERM)
-;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
-;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
-;killasgroup=false             ; SIGKILL the UNIX process group (def false)
-;user=chrism                   ; setuid to this UNIX account to run the program
-;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
-;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
-;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
-;stdout_events_enabled=false   ; emit events on stdout writes (default false)
-;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
-;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stderr_logfile_backups        ; # of stderr logfile backups (default 10)
-;stderr_events_enabled=false   ; emit events on stderr writes (default false)
-;environment=A=1,B=2           ; process environment additions
-;serverurl=AUTO                ; override serverurl computation (childutils)
-
-; The below sample group section shows all possible group values,
-; create one or more 'real' group: sections to create "heterogeneous"
-; process groups.
-
-;[group:thegroupname]
-;programs=progname1,progname2  ; each refers to 'x' in [program:x] definitions
-;priority=999                  ; the relative start priority (default 999)
-
-; The [include] section can just contain the "files" setting.  This
-; setting can list multiple files (separated by whitespace or
-; newlines).  It can also contain wildcards.  The filenames are
-; interpreted as relative to this file.  Included files *cannot*
-; include files themselves.
-
-;[include]
-;files = relative/directory/*.ini
-;mysql and apache2
 [program:mysqld]
 command=/usr/bin/mysqld_safe
 [program:httpd]
 command=/etc/apache2/foreground.sh
 stopsignal=6
-;sshd 
-;[program:sshd]
-;command=/usr/sbin/sshd -D
-;stdout_logfile=/var/log/supervisor/%(program_name)s.log
-;stderr_logfile=/var/log/supervisor/%(program_name)s.log
-;autorestart=true

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -7,7 +7,13 @@ FROM ubuntu:focal
 LABEL maintainer="Simplerisk <support@simplerisk.com>"
 
 # Make necessary directories
-RUN mkdir -p /configurations /etc/apache2/ssl /passwords /var/{log,lib/mysql,www/simplerisk}
+RUN mkdir -p /configurations \
+	     /etc/apache2/ssl \
+	     /passwords \
+	     /var/log/supervisor \
+	     /var/lib/mysql \
+	     /var/run/supervisor \
+	     /var/www/simplerisk
                                                                     
 # Installing apt dependencies     
 RUN dpkg-divert --local --rename /usr/bin/ischroot && \
@@ -40,42 +46,37 @@ RUN dpkg-divert --local --rename /usr/bin/ischroot && \
 RUN < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c21 > /passwords/pass_openssl.txt
 
 # Install and configure supervisor
-COPY common/supervisord.conf /etc/supervisord.conf
-#RUN mkdir /var/log/supervisor/
-RUN service supervisor restart
+COPY common/supervisord.conf /etc/supervisor/supervisord.conf
 
 # Configure MySQL
 RUN sed -i 's/\[mysqld\]/\[mysqld\]\nsql-mode="NO_ENGINE_SUBSTITUTION"/g' /etc/mysql/mysql.conf.d/mysqld.cnf
 
 # Configure Apache
 COPY common/foreground.sh /etc/apache2/foreground.sh
-RUN chmod 755 /etc/apache2/foreground.sh
 COPY common/envvars /etc/apache2/envvars
 COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
-RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/7.4/apache2/php.ini
-RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.4/apache2/php.ini
-RUN sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.4/apache2/php.ini
-RUN sed -i '/max_input_vars = 1000/a max_input_vars = 3000' /etc/php/7.4/apache2/php.ini
+RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.4/apache2/php.ini && \
+	sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.4/apache2/php.ini && \
+	sed -i 's/;\(max_input_vars =\) .*/\1 3000/g' /etc/php/7.4/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
-RUN mkdir -p /etc/apache2/ssl/ssl.crt
-RUN mkdir -p /etc/apache2/ssl/ssl.key
-RUN openssl genrsa -des3 -passout pass:/passwords/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl rsa -passin pass:/passwords/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
-RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
-RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
+RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \
+	openssl genrsa -des3 -passout pass:/passwords/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \
+	openssl rsa -passin pass:/passwords/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key && \
+	rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \
+	openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk" && \
+	openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
 
 # Activate Apache modules
-RUN phpenmod ldap
-RUN a2enmod rewrite
-RUN a2enmod ssl
-RUN a2enconf security
-RUN sed -i 's/SSLProtocol all -SSLv3/SSLProtocol TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
-RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
+RUN phpenmod ldap && \
+	a2enmod rewrite && \
+	a2enmod ssl && \
+	a2enconf security && \
+	sed -i 's/\(SSLProtocol\) all -SSLv3/\1 TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf && \
+	sed -i 's/#\(SSLHonorCipherOrder on\)/\1/g' /etc/apache2/mods-enabled/ssl.conf && \
+	sed -i 's/\(ServerTokens\) OS/\1 Prod/g' /etc/apache2/conf-enabled/security.conf && \
+	sed -i 's/\(ServerSignature\) On/\1 Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \
     echo "20220701-001" > /tmp/version
@@ -98,18 +99,13 @@ EXPOSE 443
 
 # Create the start script and set permissions
 COPY common/entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+RUN chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
 
 # Data to save
-VOLUME /passwords
-VOLUME /configurations
-VOLUME /var/log
-VOLUME /var/lib/mysql
-VOLUME /etc/apache2/ssl
-VOLUME /var/www/simplerisk
+VOLUME [ "/passwords", "/configurations", "/var/log", "/var/lib/mysql", "/etc/apache2/ssl", "/var/www/simplerisk" ]
 
 # Setting up entrypoint
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 # Start Apache and MySQL
-CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
+CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]

--- a/simplerisk/focal/Dockerfile
+++ b/simplerisk/focal/Dockerfile
@@ -58,7 +58,7 @@ COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/\(upload_max_filesize =\) .*\(M\)/\1 5\2/g' /etc/php/7.4/apache2/php.ini && \
 	sed -i 's/\(memory_limit =\) .*\(M\)/\1 256\2/g' /etc/php/7.4/apache2/php.ini && \
-	sed -i 's/;\(max_input_vars =\) .*/\1 3000/g' /etc/php/7.4/apache2/php.ini
+	sed -i 's/;.*\(max_input_vars =\) .*/\1 3000/g' /etc/php/7.4/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -23,7 +23,13 @@ FROM ubuntu:$image
 LABEL maintainer="Simplerisk <support@simplerisk.com>"
 
 # Make necessary directories
-RUN mkdir -p /configurations /etc/apache2/ssl /passwords /var/{log,lib/mysql,www/simplerisk}
+RUN mkdir -p /configurations \\
+	     /etc/apache2/ssl \\
+	     /passwords \\
+	     /var/log/supervisor \\
+	     /var/lib/mysql \\
+	     /var/run/supervisor \\
+	     /var/www/simplerisk
                                                                     
 # Installing apt dependencies     
 RUN dpkg-divert --local --rename /usr/bin/ischroot && \\
@@ -56,42 +62,37 @@ RUN dpkg-divert --local --rename /usr/bin/ischroot && \\
 RUN < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c21 > /passwords/pass_openssl.txt
 
 # Install and configure supervisor
-COPY common/supervisord.conf /etc/supervisord.conf
-#RUN mkdir /var/log/supervisor/
-RUN service supervisor restart
+COPY common/supervisord.conf /etc/supervisor/supervisord.conf
 
 # Configure MySQL
 RUN sed -i 's/\[mysqld\]/\[mysqld\]\nsql-mode="NO_ENGINE_SUBSTITUTION"/g' /etc/mysql/mysql.conf.d/mysqld.cnf
 
 # Configure Apache
 COPY common/foreground.sh /etc/apache2/foreground.sh
-RUN chmod 755 /etc/apache2/foreground.sh
 COPY common/envvars /etc/apache2/envvars
 COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
-RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /etc/php/$php_version/apache2/php.ini
-RUN sed -i 's/\\(upload_max_filesize =\\) .*\\(M\\)/\\1 5\\2/g' /etc/php/$php_version/apache2/php.ini
-RUN sed -i 's/\\(memory_limit =\\) .*\\(M\\)/\\1 256\\2/g' /etc/php/$php_version/apache2/php.ini
-RUN sed -i '/max_input_vars = 1000/a max_input_vars = 3000' /etc/php/$php_version/apache2/php.ini
+RUN sed -i 's/\\(upload_max_filesize =\\) .*\\(M\\)/\\1 5\\2/g' /etc/php/$php_version/apache2/php.ini && \\
+	sed -i 's/\\(memory_limit =\\) .*\\(M\\)/\\1 256\\2/g' /etc/php/$php_version/apache2/php.ini && \\
+	sed -i 's/;\\(max_input_vars =\\) .*/\\1 3000/g' /etc/php/$php_version/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
-RUN mkdir -p /etc/apache2/ssl/ssl.crt
-RUN mkdir -p /etc/apache2/ssl/ssl.key
-RUN openssl genrsa -des3 -passout pass:/passwords/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl rsa -passin pass:/passwords/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
-RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key
-RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
-RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
+RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \\
+	openssl genrsa -des3 -passout pass:/passwords/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \\
+	openssl rsa -passin pass:/passwords/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key && \\
+	rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key && \\
+	openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk" && \\
+	openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
 
 # Activate Apache modules
-RUN phpenmod ldap
-RUN a2enmod rewrite
-RUN a2enmod ssl
-RUN a2enconf security
-RUN sed -i 's/SSLProtocol all -SSLv3/SSLProtocol TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mods-enabled/ssl.conf
-RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
-RUN sed -i 's/ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
+RUN phpenmod ldap && \\
+	a2enmod rewrite && \\
+	a2enmod ssl && \\
+	a2enconf security && \\
+	sed -i 's/\\(SSLProtocol\\) all -SSLv3/\\1 TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf && \\
+	sed -i 's/#\\(SSLHonorCipherOrder on\\)/\\1/g' /etc/apache2/mods-enabled/ssl.conf && \\
+	sed -i 's/\\(ServerTokens\\) OS/\\1 Prod/g' /etc/apache2/conf-enabled/security.conf && \\
+	sed -i 's/\\(ServerSignature\\) On/\\1 Off/g' /etc/apache2/conf-enabled/security.conf
 
 RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers && \\
     echo "$release" > /tmp/version
@@ -127,20 +128,15 @@ EXPOSE 443
 
 # Create the start script and set permissions
 COPY common/entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+RUN chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
 
 # Data to save
-VOLUME /passwords
-VOLUME /configurations
-VOLUME /var/log
-VOLUME /var/lib/mysql
-VOLUME /etc/apache2/ssl
-VOLUME /var/www/simplerisk
+VOLUME [ "/passwords", "/configurations", "/var/log", "/var/lib/mysql", "/etc/apache2/ssl", "/var/www/simplerisk" ]
 
 # Setting up entrypoint
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 # Start Apache and MySQL
-CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
+CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
 EOF
 done

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -74,7 +74,7 @@ COPY common/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY common/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 RUN sed -i 's/\\(upload_max_filesize =\\) .*\\(M\\)/\\1 5\\2/g' /etc/php/$php_version/apache2/php.ini && \\
 	sed -i 's/\\(memory_limit =\\) .*\\(M\\)/\\1 256\\2/g' /etc/php/$php_version/apache2/php.ini && \\
-	sed -i 's/;\\(max_input_vars =\\) .*/\\1 3000/g' /etc/php/$php_version/apache2/php.ini
+	sed -i 's/;.*\\(max_input_vars =\\) .*/\\1 3000/g' /etc/php/$php_version/apache2/php.ini
 
 # Create SSL Certificates for Apache SSL
 RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key && \\


### PR DESCRIPTION
Detection done when checking the issue for #37.

Currently, as the container is an adapted Ubuntu image, MySQL needs to be handled by us. Curiously, when the container is stopped for the first time and started again, MySQL does not remove the locks (specifically `/var/run/mysqld/mysql{d,x}.sock.lock`) and is unable to start (the container will still run, but as the database is down, SimpleRisk will not function). But if you restart the container after that (be by using `docker stop && docker start` or `docker restart`), this behavior does not repeat, MySQL is able to run successfully.

As we already have a supervisord configuration, the idea is relying on it instead of starting Apache as a main process. It will handle both Apache and MySQL processes on start and stop. Testing the container restart process has shown that it works properly.