### PR TITLE
simplerisk-minimal: remove protocol from mysql commands

### DIFF
--- a/simplerisk-minimal/common/entrypoint.sh
+++ b/simplerisk-minimal/common/entrypoint.sh
@@ -108,7 +108,7 @@ delete_db(){
 	print_log "db_deletion: prepare" "Performing database deletion"
 
 	# Needed to separate the GRANT statement from the rest because it was providing a syntax error
-	exec_cmd "mysql --protocol=socket -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
+	exec_cmd "mysql -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
 	SET sql_mode = 'ANSI_QUOTES';
 	DROP DATABASE \"${SIMPLERISK_DB_DATABASE}\";
 	USE mysql;
@@ -139,7 +139,7 @@ db_setup(){
 
 	print_log "initial_setup:info" "Applying changes to MySQL database... (MySQL error will be printed to console as guidance)"
 	# Using sql_mode = ANSI_QUOTES to avoid using backticks
-	exec_cmd "mysql --protocol=socket -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
+	exec_cmd "mysql -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
 	SET sql_mode = 'ANSI_QUOTES';
 	CREATE DATABASE \"${SIMPLERISK_DB_DATABASE}\";
 	USE \"${SIMPLERISK_DB_DATABASE}\";
@@ -147,7 +147,7 @@ db_setup(){
 	CREATE USER \"${SIMPLERISK_DB_USERNAME}\"@\"%\" IDENTIFIED BY \"${SIMPLERISK_DB_PASSWORD}\";
 EOSQL" "Was not able to apply settings on database. Check error above. Exiting."
 	# Needed to separate the GRANT statement from the rest because it was providing a syntax error
-	exec_cmd "mysql --protocol=socket -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
+	exec_cmd "mysql -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
 	SET sql_mode = 'ANSI_QUOTES';
 	GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER ON \"${SIMPLERISK_DB_DATABASE}\".* TO \"${SIMPLERISK_DB_USERNAME}\"@\"%\";
 EOSQL" "Was not able to apply settings on database. Check error above. Exiting."

--- a/simplerisk-minimal/php81/Dockerfile
+++ b/simplerisk-minimal/php81/Dockerfile
@@ -7,14 +7,15 @@ LABEL maintainer="Simplerisk <support@simplerisk.com>"
 
 WORKDIR /var/www
 
-# Add the apt config package
-RUN apt-get update && \
-    apt-get install -y gnupg2 && \
+# Creating keyring env and installing apt dependencies
+RUN mkdir -p /etc/apt/keyrings && \
+    apt-get update && \
+    apt-get install -y gnupg2 wget && \
+    wget -qO - http://repo.mysql.com/RPM-GPG-KEY-mysql-2023 | gpg --dearmor -o /etc/apt/keyrings/mysql.gpg && \
+    echo 'deb [signed-by=/etc/apt/keyrings/mysql.gpg] http://repo.mysql.com/apt/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/ $(lsb_release -sc) mysql-8.0' | tee /etc/apt/sources.list.d/mysql.list && \
     apt-key adv --keyserver pgp.mit.edu --recv-keys A8D3785C && \
-    echo "deb http://repo.mysql.com/apt/debian bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list
-                                                                    
-# Installing apt dependencies     
-RUN apt-get update && \
+    echo "deb http://repo.mysql.com/apt/debian bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list && \
+    apt-get update && \
     apt-get -y install libldap2-dev \
                        libicu-dev \
                        libcap2-bin \

--- a/simplerisk-minimal/php83/Dockerfile
+++ b/simplerisk-minimal/php83/Dockerfile
@@ -7,14 +7,15 @@ LABEL maintainer="Simplerisk <support@simplerisk.com>"
 
 WORKDIR /var/www
 
-# Add the apt config package
-RUN apt-get update && \
-    apt-get install -y gnupg2 && \
+# Creating keyring env and installing apt dependencies
+RUN mkdir -p /etc/apt/keyrings && \
+    apt-get update && \
+    apt-get install -y gnupg2 wget && \
+    wget -qO - http://repo.mysql.com/RPM-GPG-KEY-mysql-2023 | gpg --dearmor -o /etc/apt/keyrings/mysql.gpg && \
+    echo 'deb [signed-by=/etc/apt/keyrings/mysql.gpg] http://repo.mysql.com/apt/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/ $(lsb_release -sc) mysql-8.0' | tee /etc/apt/sources.list.d/mysql.list && \
     apt-key adv --keyserver pgp.mit.edu --recv-keys A8D3785C && \
-    echo "deb http://repo.mysql.com/apt/debian bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list
-                                                                    
-# Installing apt dependencies     
-RUN apt-get update && \
+    echo "deb http://repo.mysql.com/apt/debian bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list && \
+    apt-get update && \
     apt-get -y install libldap2-dev \
                        libicu-dev \
                        libcap2-bin \


### PR DESCRIPTION
This should solve the issue of `ERROR 2047 (HY000): Wrong or unknown protocol` that should be seen when configuring the database. This is related to 5b351890e19d35ea4813956978e9b5106ee9cf83 where we change the MariaDB client to MySQL