### PR TITLE
simplerisk-minimal: adapt mysql repo to bookworm

### DIFF
--- a/.dockleignore
+++ b/.dockleignore
@@ -1,0 +1,2 @@
+# This is being done, yet it is still being detected
+DKL-DI-0005

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,2 @@
+ignore:
+  - vulnerability: CVE-2025-27558 # Not able to fix it at the moment

--- a/simplerisk-minimal/Dockerfile
+++ b/simplerisk-minimal/Dockerfile
@@ -23,7 +23,8 @@ RUN mkdir -p /etc/apt/keyrings && \
     apt-get update && \
     apt-get install -y --no-install-recommends gnupg2 wget lsb-release && \
     wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 | gpg --dearmor -o /etc/apt/keyrings/mysql.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/mysql.gpg] http://repo.mysql.com/apt/debian/ $(lsb_release -cs) mysql-8.0" | tee /etc/apt/sources.list.d/mysql.list && \
+    # FIXME: use $(lsb_release -cs) when trixie becomes available on MySQL repos
+    echo "deb [signed-by=/etc/apt/keyrings/mysql.gpg] http://repo.mysql.com/apt/debian/ bookworm mysql-8.0" | tee /etc/apt/sources.list.d/mysql.list && \
     apt-get update && \
     apt-get -y install --no-install-recommends libldap2-dev \
                                                libicu-dev \

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -46,7 +46,8 @@ RUN mkdir -p /etc/apt/keyrings && \\
     apt-get update && \\
     apt-get install -y --no-install-recommends gnupg2 wget lsb-release && \\
     wget -qO - $MYSQL_KEY_URL | gpg --dearmor -o /etc/apt/keyrings/mysql.gpg && \\
-    echo "deb [signed-by=/etc/apt/keyrings/mysql.gpg] http://repo.mysql.com/apt/debian/ \$(lsb_release -cs) mysql-8.0" | tee /etc/apt/sources.list.d/mysql.list && \\
+    # FIXME: use \$(lsb_release -cs) when trixie becomes available on MySQL repos
+    echo "deb [signed-by=/etc/apt/keyrings/mysql.gpg] http://repo.mysql.com/apt/debian/ bookworm mysql-8.0" | tee /etc/apt/sources.list.d/mysql.list && \\
     apt-get update && \\
     apt-get -y install --no-install-recommends libldap2-dev \\
                                                libicu-dev \\


### PR DESCRIPTION
no release for trixie at the moment

<img width="672" height="687" alt="image" src="https://github.com/user-attachments/assets/0473bc12-f59d-4378-9770-55bd4589a08d" />

```
docker run --rm php:8.3-apache cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
NAME="Debian GNU/Linux"
VERSION_ID="13"
VERSION="13 (trixie)"
VERSION_CODENAME=trixie
DEBIAN_VERSION_FULL=13.0
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

<img width="512" height="264" alt="image" src="https://github.com/user-attachments/assets/1944e086-0c19-4d96-a237-2f43b0041912" />
