### PR TITLE
simplerisk-minimal: use mysql 8.4

### DIFF
--- a/simplerisk-minimal/Dockerfile
+++ b/simplerisk-minimal/Dockerfile
@@ -19,7 +19,15 @@ WORKDIR /var/www
 SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
 
 #  Install required packages, including MySQL client from Debian repos
-RUN apt-get update && \
+RUN mkdir -p /etc/apt/keyrings && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gnupg2 wget lsb-release && \
+    mkdir -p /etc/apt/keyrings && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver keys.gnupg.net --recv-keys B7B3B788A8D3785C && \
+    gpg --batch --export B7B3B788A8D3785C > /etc/apt/trusted.gpg.d/mysql.gpg && \
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/mysql.gpg] http://repo.mysql.com/apt/debian/ trixie mysql-8.4-lts" | tee /etc/apt/sources.list.d/mysql.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         libldap2-dev \
         libicu-dev \
@@ -33,8 +41,7 @@ RUN apt-get update && \
         rsyslog \
         logrotate \
         curl \
-        # This will install mariadb-client
-        default-mysql-client && \
+        mysql-community-client && \
     apt-get -y autoremove && \
     apt-get -y purge && \
     rm -rf /var/lib/apt/lists/*

--- a/simplerisk-minimal/common/entrypoint.sh
+++ b/simplerisk-minimal/common/entrypoint.sh
@@ -108,7 +108,7 @@ delete_db(){
 	print_log "db_deletion: prepare" "Performing database deletion"
 
 	# Needed to separate the GRANT statement from the rest because it was providing a syntax error
-	exec_cmd "mysql --skip-ssl -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
+	exec_cmd "mysql -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
 	SET sql_mode = 'ANSI_QUOTES';
 	DROP DATABASE \"${SIMPLERISK_DB_DATABASE}\";
 	USE mysql;
@@ -138,7 +138,7 @@ db_setup(){
 
 	print_log "initial_setup:info" "Applying changes to MySQL database... (MySQL error will be printed to console as guidance)"
 	# Using sql_mode = ANSI_QUOTES to avoid using backticks
-	exec_cmd "mysql --skip-ssl -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
+	exec_cmd "mysql -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
 	SET sql_mode = 'ANSI_QUOTES';
 	CREATE DATABASE \"${SIMPLERISK_DB_DATABASE}\";
 	USE \"${SIMPLERISK_DB_DATABASE}\";
@@ -146,7 +146,7 @@ db_setup(){
 	CREATE USER \"${SIMPLERISK_DB_USERNAME}\"@\"%\" IDENTIFIED BY \"${SIMPLERISK_DB_PASSWORD}\";
 EOSQL" "Was not able to apply settings on database. Check error above. Exiting."
 	# Needed to separate the GRANT statement from the rest because it was providing a syntax error
-	exec_cmd "mysql --skip-ssl -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
+	exec_cmd "mysql -u $DB_SETUP_USER -p$DB_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
 	SET sql_mode = 'ANSI_QUOTES';
 	GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER ON \"${SIMPLERISK_DB_DATABASE}\".* TO \"${SIMPLERISK_DB_USERNAME}\"@\"%\";
 EOSQL" "Was not able to apply settings on database. Check error above. Exiting."

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -41,7 +41,15 @@ WORKDIR /var/www
 SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
 
 #  Install required packages, including MySQL client from Debian repos
-RUN apt-get update && \\
+RUN mkdir -p /etc/apt/keyrings && \\
+    apt-get update && \\
+    apt-get install -y --no-install-recommends gnupg2 wget lsb-release && \\
+    mkdir -p /etc/apt/keyrings && \\
+    export GNUPGHOME="\$(mktemp -d)" && \\
+    gpg --batch --keyserver keys.gnupg.net --recv-keys B7B3B788A8D3785C && \\ # Key taken from https://dev.mysql.com/doc/refman/8.4/en/checking-gpg-signature.html
+    gpg --batch --export B7B3B788A8D3785C > /etc/apt/trusted.gpg.d/mysql.gpg && \\
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/mysql.gpg] http://repo.mysql.com/apt/debian/ trixie mysql-8.4-lts" | tee /etc/apt/sources.list.d/mysql.list && \\
+    apt-get update && \\
     apt-get install -y --no-install-recommends \\
         libldap2-dev \\
         libicu-dev \\
@@ -55,8 +63,7 @@ RUN apt-get update && \\
         rsyslog \\
         logrotate \\
         curl \\
-        # This will install mariadb-client
-        default-mysql-client && \\
+        mysql-community-client && \\
     apt-get -y autoremove && \\
     apt-get -y purge && \\
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
PR https://github.com/simplerisk/docker/pull/120 installs MariaDB because the method to install MySQL has been changed. This PR reinstalls MySQL with the new method.