### PR TITLE
simplerisk: set USE_DATABASE_FOR_SESSIONS to true in config.php

### DIFF
--- a/simplerisk/common/entrypoint.sh
+++ b/simplerisk/common/entrypoint.sh
@@ -53,6 +53,7 @@ set_config(){
 		SIMPLERISK_DB_USERNAME=simplerisk && sed -i "s/\('DB_USERNAME', '\).*\(');\)/\1$SIMPLERISK_DB_USERNAME\2/g" $CONFIG_PATH
 		set_db_password
 		SIMPLERISK_DB_DATABASE=simplerisk && sed -i "s/\('DB_DATABASE', '\).*\(');\)/\1$SIMPLERISK_DB_DATABASE\2/g" $CONFIG_PATH
+		sed -i "s/\('USE_DATABASE_FOR_SESSIONS', '\).*\(');\)/\1true\2/g" $CONFIG_PATH
 
 		# Create a file so this doesn't run again
 		touch /configurations/simplerisk-config-configured


### PR DESCRIPTION
## Summary
- The full-stack `simplerisk/common/entrypoint.sh` was not substituting the `__USE_DATABASE_FOR_SESSIONS__` placeholder shipped in `config.sample.php`, so the generated `config.php` contained `define('USE_DATABASE_FOR_SESSIONS', '__USE_DATABASE_FOR_SESSIONS__');` — an invalid value.
- Adds a `sed` substitution alongside the other DB substitutions in `set_config` that hardcodes the value to `true`.
- The `simplerisk-minimal` image already handles this (via the `SIMPLERISK_DB_FOR_SESSIONS` env var, defaulting to `true`). The full-stack image bundles MySQL and hardcodes all other DB-related values, so keeping this hardcoded matches that pattern — no new env var introduced.

## Test plan
- [x] Build the full-stack image locally (`docker build -t simplerisk/simplerisk:test-uds simplerisk/`)
- [x] Run a container and confirm `/var/www/simplerisk/includes/config.php` contains `define('USE_DATABASE_FOR_SESSIONS', 'true');` — no placeholder remaining
- [ ] CI: container-validation workflow (Dockle + Grype) passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)