### PR TITLE
Use a fixed bootstrap password for the simplerisk-minimal stack

### DIFF
--- a/simplerisk-minimal/README.md
+++ b/simplerisk-minimal/README.md
@@ -4,6 +4,8 @@
 
 This image is intended to run SimpleRisk in a 'microservices' approach (database is not included). It uses PHP 8.X with Apache as a base image. Also has the capability of setting properties of the `config.php` file through environment variables.
 
+> **Two passwords, two roles.** `DB_SETUP_PASS` / `MYSQL_ROOT_PASSWORD` is the *bootstrap* credential the entrypoint uses to create the database and the application's DB user during first-run setup — in the bundled `stack.yml` it defaults to `simplerisk_setup` and guards a MySQL that is only reachable inside the stack network. `SIMPLERISK_DB_PASSWORD` is the *application* credential SimpleRisk uses at runtime; if you do not supply one it is randomly generated per deployment and printed to the container log. Set both explicitly for production use.
+
 For any of the executions, it is recommended to map the 80 and 443 ports to be able to access the application.
 
 ## Build
@@ -60,7 +62,7 @@ docker run -d --name simplerisk -e SIMPLERISK_DB_PASSWORD=pass -e SIMPLERISK_DB_
 |:-------------:|:-------------:|:--------|
 | `DB_SETUP` | `null` (Accepts any value) | The container will start as if the database has not been set up. The valid options here are `automatic` (in case you want the container to configure the database), `automatic-only` (the same as `automatic`, but stops the container after finishing the setup), `delete` (removes the SimpleRisk database and user from MySQL) or `manual` (allows the user to run the manual installation) |
 | `DB_SETUP_USER` | `root` | Used when `DB_SETUP=automatic\|automatic-only\|delete`. User name of database privileged user to install SimpleRisk schema and other components |
-| `DB_SETUP_PASS` | `root` | Used when `DB_SETUP=automatic\|automatic-only\|delete`. Password for database privileged user to install SimpleRisk schema and other components |
+| `DB_SETUP_PASS` | `root` (the bundled `stack.yml` ships `simplerisk_setup`) | Used when `DB_SETUP=automatic\|automatic-only\|delete`. Password of the privileged MySQL user used **only** to install the SimpleRisk schema and create the app DB user. In `stack.yml` it is also the bundled MySQL root password; since that MySQL is not exposed outside the stack network, a documented default is used for the zero-config trial. Override it (and `MYSQL_ROOT_PASSWORD` in `stack.yml`) for any non-trial deployment. |
 | `DB_SETUP_WAIT` | 20 | Used when `DB_SETUP=automatic\|automatic-only`. Time, in seconds, the application is going to wait to set up the database. Useful if you are deploying the database and SimpleRisk at the same time |
 | `SIMPLERISK_DB_HOSTNAME` | `localhost` | Hostname of the database server |
 | `SIMPLERISK_DB_PORT` | 3306 | Port to contact the database |

--- a/simplerisk-minimal/stack.yml
+++ b/simplerisk-minimal/stack.yml
@@ -6,7 +6,7 @@ services:
   simplerisk:
     environment:
     - DB_SETUP=automatic
-    - DB_SETUP_PASS=Q29xIQhisPq8rDzjbzZKd
+    - DB_SETUP_PASS=simplerisk_setup
     - SIMPLERISK_DB_HOSTNAME=mysql
     image: simplerisk/simplerisk-minimal:20260519-001
     ports:
@@ -16,7 +16,7 @@ services:
   mysql:
     command: mysqld --sql_mode="NO_ENGINE_SUBSTITUTION"
     environment:
-    - MYSQL_ROOT_PASSWORD=Q29xIQhisPq8rDzjbzZKd
+    - MYSQL_ROOT_PASSWORD=simplerisk_setup
     image: mysql:8.0
 
   smtp:

--- a/simplerisk-minimal/update_stack_and_workflows.sh
+++ b/simplerisk-minimal/update_stack_and_workflows.sh
@@ -5,12 +5,15 @@ set -euo pipefail
 SCRIPT_LOCATION="$(dirname "$(readlink -f "$0")")"
 readonly SCRIPT_LOCATION
 
-generate_random_password() {
-    echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-21})
-}
-
 [ -z "${1:-}" ] && echo "No release version provided. Aborting." && exit 1 || release=$1
-pass=$(generate_random_password)
+
+# Fixed bootstrap password for the bundled MySQL. It is the root password used
+# ONLY for first-run schema setup; mysql is not exposed outside the stack
+# network, and SimpleRisk generates its own random application DB password at
+# first run. Override DB_SETUP_PASS + MYSQL_ROOT_PASSWORD below for any
+# non-trial deployment. Kept literal (not randomized) so the committed
+# stack.yml is deterministic across releases.
+readonly bootstrap_pass="simplerisk_setup"
 
 cat << EOF > "$SCRIPT_LOCATION/stack.yml"
 # Compose file generated automatically
@@ -21,7 +24,7 @@ services:
   simplerisk:
     environment:
     - DB_SETUP=automatic
-    - DB_SETUP_PASS=$pass
+    - DB_SETUP_PASS=$bootstrap_pass
     - SIMPLERISK_DB_HOSTNAME=mysql
     image: simplerisk/simplerisk-minimal:$release
     ports:
@@ -31,7 +34,7 @@ services:
   mysql:
     command: mysqld --sql_mode="NO_ENGINE_SUBSTITUTION"
     environment:
-    - MYSQL_ROOT_PASSWORD=$pass
+    - MYSQL_ROOT_PASSWORD=$bootstrap_pass
     image: mysql:8.0
 
   smtp:


### PR DESCRIPTION
## Description

`update_stack_and_workflows.sh` regenerated `simplerisk-minimal/stack.yml` with a fresh random password on every run, written to both `DB_SETUP_PASS` and `MYSQL_ROOT_PASSWORD`. That value is the **bundled MySQL bootstrap/root password used only for first-run schema setup** — mysql is not exposed outside the stack network, and SimpleRisk already generates its own random *application* DB password (`SIMPLERISK_DB_PASSWORD`) at first run. Randomizing a value that is then committed to this public repo is not a secret; it also made `stack.yml` non-deterministic, so code-development's new `bump_downstream_versions.yml` force-pushed docker on every run.

This ships a fixed, documented default (`simplerisk_setup`): the committed file becomes deterministic (a version bump changes only the image tag), the trial one-click still works zero-input under both `docker compose up` and Swarm `docker stack deploy`, and the README now distinguishes the bootstrap vs application passwords.

**No image or entrypoint change** — the `simplerisk-minimal` image (used by the EKS deployment) is untouched. EKS supplies `DB_SETUP_PASS` via its own Kubernetes Secret and does not read `stack.yml`, so nothing in its path changes.

Design: code-development `docs/superpowers/specs/2026-06-07-docker-stack-bootstrap-password-design.md`.

## Testing

- **Generator determinism**: running `update_stack_and_workflows.sh <version>` twice produces byte-identical output; a version-only change moves just the image tag (verified locally).
- **Stack boot** (`docker compose -f simplerisk-minimal/stack.yml up -d`): first-run setup completed with the bootstrap password ("Setup has been applied successfully!") and the log showed an auto-generated `SIMPLERISK_DB_PASSWORD` ("a random password has been generated (...)"), confirming the committed bootstrap value only gates setup and the application credential is random per deployment.
- container-validation.yml CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
