### PR TITLE
fix: run update-ca-certificates after apt-get in simplerisk image

### DIFF
--- a/simplerisk/Dockerfile
+++ b/simplerisk/Dockerfile
@@ -61,7 +61,8 @@ RUN dpkg-divert --local --rename /usr/bin/ischroot && \
                                                                               curl \
                                                                               ca-certificates \
                                                                               supervisor && \
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists && \
+    update-ca-certificates
 
 # Create the OpenSSL password
 RUN echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32})" > /passwords/pass_openssl.txt

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -83,7 +83,8 @@ RUN dpkg-divert --local --rename /usr/bin/ischroot && \\
                                                                               curl \\
                                                                               ca-certificates \\
                                                                               supervisor && \\
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists && \\
+    update-ca-certificates
 
 # Create the OpenSSL password
 RUN echo "\$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c\${1:-32})" > /passwords/pass_openssl.txt


### PR DESCRIPTION
## Summary

- `ca-certificates` is installed via `apt-get` but `update-ca-certificates` is never called during the build, so `/etc/ssl/certs/ca-certificates.crt` is absent from the resulting image
- PHP's `libcurl` is compiled with that path as its default CA bundle (`--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt`), so any outbound HTTPS request via PHP's cURL extension fails immediately with `error setting certificate file: /etc/ssl/certs/ca-certificates.crt`
- Fix: chain `update-ca-certificates` at the end of the existing `apt-get install` RUN layer in `simplerisk/generate_dockerfile.sh`, then regenerate `simplerisk/Dockerfile`

**Note:** `simplerisk-minimal` is unaffected — it already calls `update-ca-certificates` as part of its SSL certificate generation step.

## Reproduction

On a fresh container from `simplerisk/simplerisk:latest`, any PHP cURL HTTPS call fails:

```
error setting certificate file: /etc/ssl/certs/ca-certificates.crt
```

The file is absent because `apt-get install ca-certificates` installs the package but the post-install hook that generates the bundle (`update-ca-certificates`) is not triggered during the Docker build.

## Fix

In `simplerisk/generate_dockerfile.sh`, added `&& update-ca-certificates` at the end of the apt-get RUN block:

```dockerfile
    rm -rf /var/lib/apt/lists && \
    update-ca-certificates
```

## Test plan

- [ ] Autobuild completes successfully
- [ ] `/etc/ssl/certs/ca-certificates.crt` exists in the built image
- [ ] PHP cURL HTTPS requests succeed in a fresh container

🤖 Generated with [Claude Code](https://claude.com/claude-code)