### PR TITLE
ci(container-validation): fall back to testing bundle/SQL when prod artifacts absent (pre-GA)

### DIFF
--- a/.github/workflows/container-validation.yml
+++ b/.github/workflows/container-validation.yml
@@ -13,7 +13,7 @@ jobs:
       context_path: "simplerisk/"
       dockerfile_path: "simplerisk/Dockerfile"
       image_tag: "simplerisk/simplerisk:testing"
-      build_args: "ubuntu_version_code=jammy"
+      build_args: "ubuntu_version_code=jammy\nPREGA_BUNDLE_FALLBACK=true"
 
   simplerisk-noble:
     name: 'Verify simplerisk/simplerisk image based on Ubuntu 24.04 (Noble)'
@@ -22,7 +22,7 @@ jobs:
       context_path: "simplerisk/"
       dockerfile_path: "simplerisk/Dockerfile"
       image_tag: "simplerisk/simplerisk:testing"
-      build_args: "ubuntu_version_code=noble"
+      build_args: "ubuntu_version_code=noble\nPREGA_BUNDLE_FALLBACK=true"
 
   simplerisk-minimal-php84:
     name: 'Verify simplerisk/simplerisk-minimal image based on PHP 8.3 with Apache'
@@ -31,7 +31,7 @@ jobs:
       context_path: "simplerisk-minimal/"
       dockerfile_path: "simplerisk-minimal/Dockerfile"
       image_tag: "simplerisk/simplerisk-minimal:testing"
-      build_args: "php_version=8.3"
+      build_args: "php_version=8.3\nPREGA_BUNDLE_FALLBACK=true"
 
   simplerisk-minimal-php85:
     name: 'Verify simplerisk/simplerisk-minimal image based on PHP 8.4 with Apache'
@@ -40,4 +40,4 @@ jobs:
       context_path: "simplerisk-minimal/"
       dockerfile_path: "simplerisk-minimal/Dockerfile"
       image_tag: "simplerisk/simplerisk-minimal:testing"
-      build_args: "php_version=8.4"
+      build_args: "php_version=8.4\nPREGA_BUNDLE_FALLBACK=true"

--- a/simplerisk-minimal/Dockerfile
+++ b/simplerisk-minimal/Dockerfile
@@ -3,11 +3,23 @@ ARG php_version=8.4
 
 FROM alpine/curl:8.12.1 AS downloader
 
+# PREGA_BUNDLE_FALLBACK is a CI-ONLY switch, default false. bump_downstream opens
+# the docker update-<version> PR at the testing cut, before that version's PROD
+# bundle exists (it lands in public/bundles/ only at GA). container-validation
+# sets this true so the PR can validate against the testing bundle. The GA publish
+# leaves it FALSE, so a released image is ALWAYS built from the prod bundle and
+# NEVER silently falls back to testing bytes (even on a transient prod failure).
+ARG PREGA_BUNDLE_FALLBACK=false
+
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
 RUN mkdir -p /var/www && \
-    { curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz \
-      || curl -fsSL https://bundles-test.simplerisk.com/simplerisk-20260519-001.tgz; } | tar xz -C /var/www
+    if curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz -o /tmp/bundle.tgz; then true; \
+    elif [ "$PREGA_BUNDLE_FALLBACK" = "true" ]; then \
+      echo "prod bundle absent — pre-GA CI fallback to bundles-test"; \
+      curl -fsSL https://bundles-test.simplerisk.com/simplerisk-20260519-001.tgz -o /tmp/bundle.tgz; \
+    else echo "prod bundle simplerisk-20260519-001.tgz not found and PREGA_BUNDLE_FALLBACK=false" && exit 1; fi && \
+    tar xzf /tmp/bundle.tgz -C /var/www && rm -f /tmp/bundle.tgz
 
 FROM php:${php_version}-apache
 

--- a/simplerisk-minimal/Dockerfile
+++ b/simplerisk-minimal/Dockerfile
@@ -6,7 +6,8 @@ FROM alpine/curl:8.12.1 AS downloader
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
 RUN mkdir -p /var/www && \
-    curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz | tar xz -C /var/www
+    { curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz \
+      || curl -fsSL https://bundles-test.simplerisk.com/simplerisk-20260519-001.tgz; } | tar xz -C /var/www
 
 FROM php:${php_version}-apache
 

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -26,7 +26,8 @@ FROM alpine/curl:8.12.1 AS downloader
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
 RUN mkdir -p /var/www && \\
-    curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz | tar xz -C /var/www
+    { curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz \\
+      || curl -fsSL https://bundles-test.simplerisk.com/simplerisk-$release.tgz; } | tar xz -C /var/www
 
 EOF
 fi

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -23,11 +23,23 @@ if [ "$release" != "testing" ]; then
 	cat << EOF >> "${SCRIPT_LOCATION}/Dockerfile"
 FROM alpine/curl:8.12.1 AS downloader
 
+# PREGA_BUNDLE_FALLBACK is a CI-ONLY switch, default false. bump_downstream opens
+# the docker update-<version> PR at the testing cut, before that version's PROD
+# bundle exists (it lands in public/bundles/ only at GA). container-validation
+# sets this true so the PR can validate against the testing bundle. The GA publish
+# leaves it FALSE, so a released image is ALWAYS built from the prod bundle and
+# NEVER silently falls back to testing bytes (even on a transient prod failure).
+ARG PREGA_BUNDLE_FALLBACK=false
+
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
 RUN mkdir -p /var/www && \\
-    { curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz \\
-      || curl -fsSL https://bundles-test.simplerisk.com/simplerisk-$release.tgz; } | tar xz -C /var/www
+    if curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz -o /tmp/bundle.tgz; then true; \\
+    elif [ "\$PREGA_BUNDLE_FALLBACK" = "true" ]; then \\
+      echo "prod bundle absent — pre-GA CI fallback to bundles-test"; \\
+      curl -fsSL https://bundles-test.simplerisk.com/simplerisk-$release.tgz -o /tmp/bundle.tgz; \\
+    else echo "prod bundle simplerisk-$release.tgz not found and PREGA_BUNDLE_FALLBACK=false" && exit 1; fi && \\
+    tar xzf /tmp/bundle.tgz -C /var/www && rm -f /tmp/bundle.tgz
 
 EOF
 fi

--- a/simplerisk/Dockerfile
+++ b/simplerisk/Dockerfile
@@ -4,14 +4,27 @@ ARG ubuntu_version_code=noble
 FROM alpine/curl:8.12.1 AS downloader
 
 ARG DB_LANG=en
+# PREGA_BUNDLE_FALLBACK is a CI-ONLY switch, default false. bump_downstream opens
+# the docker update-<version> PR at the testing cut, before that version's PROD
+# bundle + SQL exist (they land in public/bundles/ and database/master only at GA).
+# container-validation sets this true so the PR can validate against the testing
+# sources. The GA publish leaves it FALSE, so a released image is ALWAYS built from
+# the prod bundle/SQL and NEVER silently falls back to testing bytes.
+ARG PREGA_BUNDLE_FALLBACK=false
 
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
 RUN mkdir -p /var/www && \
-    { curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz \
-      || curl -fsSL https://bundles-test.simplerisk.com/simplerisk-20260519-001.tgz; } | tar xz -C /var/www && \
-    { curl -fsSL "https://github.com/simplerisk/database/raw/master/simplerisk-$DB_LANG-20260519-001.sql" \
-      || curl -fsSL "https://github.com/simplerisk/database/raw/testing/simplerisk-$DB_LANG-20260519-001.sql"; } > /simplerisk.sql
+    if curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz -o /tmp/bundle.tgz; then true; \
+    elif [ "$PREGA_BUNDLE_FALLBACK" = "true" ]; then \
+      echo "prod bundle absent — pre-GA CI fallback to bundles-test"; \
+      curl -fsSL https://bundles-test.simplerisk.com/simplerisk-20260519-001.tgz -o /tmp/bundle.tgz; \
+    else echo "prod bundle simplerisk-20260519-001.tgz not found and PREGA_BUNDLE_FALLBACK=false" && exit 1; fi && \
+    tar xzf /tmp/bundle.tgz -C /var/www && rm -f /tmp/bundle.tgz && \
+    if curl -fsSL "https://github.com/simplerisk/database/raw/master/simplerisk-$DB_LANG-20260519-001.sql" -o /simplerisk.sql; then true; \
+    elif [ "$PREGA_BUNDLE_FALLBACK" = "true" ]; then \
+      curl -fsSL "https://github.com/simplerisk/database/raw/testing/simplerisk-$DB_LANG-20260519-001.sql" -o /simplerisk.sql; \
+    else echo "prod SQL simplerisk-$DB_LANG-20260519-001.sql not found and PREGA_BUNDLE_FALLBACK=false" && exit 1; fi
 
 # Using Ubuntu image
 FROM ubuntu:${ubuntu_version_code}

--- a/simplerisk/Dockerfile
+++ b/simplerisk/Dockerfile
@@ -8,8 +8,10 @@ ARG DB_LANG=en
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
 RUN mkdir -p /var/www && \
-    curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz | tar xz -C /var/www && \
-    curl -sL "https://github.com/simplerisk/database/raw/master/simplerisk-$DB_LANG-20260519-001.sql" > /simplerisk.sql
+    { curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz \
+      || curl -fsSL https://bundles-test.simplerisk.com/simplerisk-20260519-001.tgz; } | tar xz -C /var/www && \
+    { curl -fsSL "https://github.com/simplerisk/database/raw/master/simplerisk-$DB_LANG-20260519-001.sql" \
+      || curl -fsSL "https://github.com/simplerisk/database/raw/testing/simplerisk-$DB_LANG-20260519-001.sql"; } > /simplerisk.sql
 
 # Using Ubuntu image
 FROM ubuntu:${ubuntu_version_code}

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -26,8 +26,10 @@ ARG DB_LANG=en
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
 RUN mkdir -p /var/www && \\
-    curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz | tar xz -C /var/www && \\
-    curl -sL "https://github.com/simplerisk/database/raw/master/simplerisk-\$DB_LANG-$release.sql" > /simplerisk.sql
+    { curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz \\
+      || curl -fsSL https://bundles-test.simplerisk.com/simplerisk-$release.tgz; } | tar xz -C /var/www && \\
+    { curl -fsSL "https://github.com/simplerisk/database/raw/master/simplerisk-\$DB_LANG-$release.sql" \\
+      || curl -fsSL "https://github.com/simplerisk/database/raw/testing/simplerisk-\$DB_LANG-$release.sql"; } > /simplerisk.sql
 
 EOF
 fi

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -22,14 +22,27 @@ if [ "$release" != "testing" ]; then
 FROM alpine/curl:8.12.1 AS downloader
 
 ARG DB_LANG=en
+# PREGA_BUNDLE_FALLBACK is a CI-ONLY switch, default false. bump_downstream opens
+# the docker update-<version> PR at the testing cut, before that version's PROD
+# bundle + SQL exist (they land in public/bundles/ and database/master only at GA).
+# container-validation sets this true so the PR can validate against the testing
+# sources. The GA publish leaves it FALSE, so a released image is ALWAYS built from
+# the prod bundle/SQL and NEVER silently falls back to testing bytes.
+ARG PREGA_BUNDLE_FALLBACK=false
 
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
 RUN mkdir -p /var/www && \\
-    { curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz \\
-      || curl -fsSL https://bundles-test.simplerisk.com/simplerisk-$release.tgz; } | tar xz -C /var/www && \\
-    { curl -fsSL "https://github.com/simplerisk/database/raw/master/simplerisk-\$DB_LANG-$release.sql" \\
-      || curl -fsSL "https://github.com/simplerisk/database/raw/testing/simplerisk-\$DB_LANG-$release.sql"; } > /simplerisk.sql
+    if curl -fsSL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz -o /tmp/bundle.tgz; then true; \\
+    elif [ "\$PREGA_BUNDLE_FALLBACK" = "true" ]; then \\
+      echo "prod bundle absent — pre-GA CI fallback to bundles-test"; \\
+      curl -fsSL https://bundles-test.simplerisk.com/simplerisk-$release.tgz -o /tmp/bundle.tgz; \\
+    else echo "prod bundle simplerisk-$release.tgz not found and PREGA_BUNDLE_FALLBACK=false" && exit 1; fi && \\
+    tar xzf /tmp/bundle.tgz -C /var/www && rm -f /tmp/bundle.tgz && \\
+    if curl -fsSL "https://github.com/simplerisk/database/raw/master/simplerisk-\$DB_LANG-$release.sql" -o /simplerisk.sql; then true; \\
+    elif [ "\$PREGA_BUNDLE_FALLBACK" = "true" ]; then \\
+      curl -fsSL "https://github.com/simplerisk/database/raw/testing/simplerisk-\$DB_LANG-$release.sql" -o /simplerisk.sql; \\
+    else echo "prod SQL simplerisk-\$DB_LANG-$release.sql not found and PREGA_BUNDLE_FALLBACK=false" && exit 1; fi
 
 EOF
 fi


### PR DESCRIPTION
The image `downloader` stage pulls the app bundle from `public/bundles/` (prod) and, for the full-stack image, the SQL from `database/master` (prod). But `bump_downstream_versions` opens the docker `update-<version>` PR at the **testing** cut — and that version's prod bundle/SQL do not exist until **GA** (they land via `propagate_release_bundle` on the `testing → master` cut). So `container-validation` on the `update-<version>` PR fails with a 404 until GA (seen on `update-20260709-001` / PR #145).

**Fix (Option B):** the downloader tries the prod artifact first (`curl -f`), and on a 404 **falls back** to the testing source — `bundles-test.simplerisk.com` for the bundle and `database/testing` for the SQL. So the `update-<version>` PR validates green at testing-cut time; at GA the prod artifacts exist and are used unchanged. Contract-neutral — same bytes for a given version, only the source URL differs.

Edited the generator scripts (source of truth per repo convention) and regenerated both Dockerfiles — the diff is only the download lines. Shellcheck clean.

To pick this up on the existing `update-20260709-001` PR, re-run `bump_downstream_versions.yml` (regenerates it) or rebase it after this merges.