### PR TITLE
GA promote (no rebuild): retag :latest to the RC digest + manual dispatch (Plan 2)

### DIFF
--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -1,22 +1,17 @@
 name: Promote latest image tag (release)
 
-# On a release (push to master that bumps the version), promote the customers-cdk
-# `latest` channel: write SSM /simplerisk/customers/image-tag/latest = <VERSION> in
-# the customers account via OIDC, so the image-updater Lambda rolls tier=latest
-# (production) services onto the just-published release image.
+# GA promotion for simplerisk-minimal, run MANUALLY (workflow_dispatch) once the
+# release has merged to master. Build-once model: the RC image was already built
+# by publish-testing.yml at the testing cut (tags <VERSION>-php83/84/85 + bare
+# <VERSION>). GA does NOT rebuild — it (1) retags DockerHub :latest to the
+# existing <VERSION>-php85 digest via `buildx imagetools create` (multi-arch
+# preserved), and (2) writes SSM /simplerisk/customers/image-tag/latest =
+# <VERSION>-php85 in the customers account (OIDC), so the image-updater Lambda
+# rolls tier=latest (production) services onto the promoted digest.
 #
-# The release IMAGE itself is built + pushed (:latest + :<VERSION>) by the existing
-# push-to-dockerhub workflow on the same master push — this workflow ONLY does the
-# cross-account SSM promote (the missing automation link). Path-filtered to the
-# minimal Dockerfile so a docs-only master push does not roll production.
-#
-# See design docs/superpowers/specs/2026-07-01-testing-image-promote (customers-cdk).
+# See design code-development docs/superpowers/specs/2026-07-10-release-image-promotion-design.
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - simplerisk-minimal/Dockerfile
   workflow_dispatch:
 
 permissions:
@@ -38,6 +33,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Read release version from the minimal Dockerfile
         id: ver
         run: |
@@ -51,6 +55,23 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Verify the RC image exists, then retag :latest → <VERSION>-php85
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          IMAGE_NAME: simplerisk/simplerisk-minimal
+        run: |
+          set -euo pipefail
+          # The php85 immutable tag MUST already exist (built by publish-testing
+          # at the RC cut). Fail loudly rather than silently promoting nothing.
+          if ! docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}-php85" >/dev/null 2>&1; then
+            echo "::error::${IMAGE_NAME}:${VERSION}-php85 not found on Docker Hub — was the RC published (Plan 1)?"; exit 1
+          fi
+          # Retag (no rebuild): create :latest from the existing multi-arch digest.
+          docker buildx imagetools create \
+            --tag "${IMAGE_NAME}:latest" \
+            "${IMAGE_NAME}:${VERSION}-php85"
+          echo "retagged ${IMAGE_NAME}:latest -> ${VERSION}-php85 digest" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Configure AWS credentials (OIDC → customers account)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -63,6 +84,6 @@ jobs:
         run: |
           set -euo pipefail
           aws ssm put-parameter --name "$SSM_PARAM" \
-            --value "$VERSION" --type String --overwrite \
+            --value "${VERSION}-php85" --type String --overwrite \
             --region "$AWS_REGION"
-          echo "promoted $SSM_PARAM = $VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "promoted $SSM_PARAM = ${VERSION}-php85" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -66,6 +66,16 @@ jobs:
           if ! docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}-php85" >/dev/null 2>&1; then
             echo "::error::${IMAGE_NAME}:${VERSION}-php85 not found on Docker Hub — was the RC published (Plan 1)?"; exit 1
           fi
+          # Currency guard: only promote the version that is CURRENTLY in testing.
+          # :testing floats to the current RC (publish-testing tags <V>-php85 and
+          # :testing on the same build), so the digests match iff VERSION is the
+          # current RC. Prevents a stale committed Dockerfile version (or a stale
+          # dispatch ref) from promoting an old-but-existing release to prod :latest.
+          SRC_DIGEST=$(docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}-php85" --format '{{.Manifest.Digest}}')
+          TESTING_DIGEST=$(docker buildx imagetools inspect "${IMAGE_NAME}:testing" --format '{{.Manifest.Digest}}')
+          if [ "$SRC_DIGEST" != "$TESTING_DIGEST" ]; then
+            echo "::error::${IMAGE_NAME}:${VERSION}-php85 ($SRC_DIGEST) is not the current testing RC ($TESTING_DIGEST) — refusing to promote a stale version to :latest"; exit 1
+          fi
           # Retag (no rebuild): create :latest from the existing multi-arch digest.
           docker buildx imagetools create \
             --tag "${IMAGE_NAME}:latest" \
@@ -78,7 +88,7 @@ jobs:
           role-to-assume: ${{ vars.IMAGE_PROMOTER_LATEST_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Promote — SSM /image-tag/latest = <VERSION>
+      - name: Promote — SSM /image-tag/latest = <VERSION>-php85
         env:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -36,28 +36,3 @@ jobs:
       main_image: true
       build_args: "ubuntu_version_code=noble"
     secrets: inherit
-  simplerisk-minimal-php84:
-    name: 'Push simplerisk/simplerisk-minimal image based on PHP 8.3 with Apache'
-    uses: ./.github/workflows/push-to-dockerhub_rw.yml
-    with:
-      context_path: "simplerisk-minimal"
-      dockerfile_path: "simplerisk-minimal/Dockerfile"
-      image_name: "simplerisk/simplerisk-minimal"
-      version: "20260519-001"
-      os_version: "php83"
-      build_args: "php_version=8.3"
-      platforms: linux/amd64,linux/arm64
-    secrets: inherit
-  simplerisk-minimal-php85:
-    name: 'Push simplerisk/simplerisk-minimal image based on PHP 8.4 with Apache'
-    uses: ./.github/workflows/push-to-dockerhub_rw.yml
-    with:
-      context_path: "simplerisk-minimal"
-      dockerfile_path: "simplerisk-minimal/Dockerfile"
-      image_name: "simplerisk/simplerisk-minimal"
-      version: "20260519-001"
-      os_version: "php84"
-      main_image: true
-      build_args: "php_version=8.4"
-      platforms: linux/amd64,linux/arm64
-    secrets: inherit


### PR DESCRIPTION
## Summary

Plan 2 of the build-once-promote redesign. Makes GA of `simplerisk-minimal` a **promotion of the already-built RC digest** — no rebuild — building on Plan 1 (#147, merged to `testing`).

Design + plan (code-development `docs/superpowers/`):
`specs/2026-07-10-release-image-promotion-design.md`, `plans/2026-07-10-docker-ga-promote-no-rebuild.md`.

## What changed (3 commits)

- **`promote-latest.yml`** — now a **manual `workflow_dispatch`** (no auto-promote on push). It (1) verifies the RC `<V>-php85` tag exists, (2) **currency-guards** it (its digest must equal the floating `:testing` digest, so a stale committed version / stale dispatch ref can't promote an old release to prod), (3) retags DockerHub `:latest` → the `<V>-php85` digest via `docker buildx imagetools create` (multi-arch preserved, **no build step**), and (4) sets prod SSM `/simplerisk/customers/image-tag/latest = <V>-php85`.
- **`push-to-dockerhub.yml`** — removed the two `simplerisk-minimal-*` jobs, so the master push no longer rebuilds the minimal image (full-stack `simplerisk` jammy/noble still rebuild). The minimal `<V>`/`<V>-php8x` tags come only from Plan 1's testing build; `:latest` moves only via the manual promote.

## What is intentionally NOT changed

- **GHCR** (`push-to-gh-pkgs.yml`) keeps its independent minimal rebuild (out of build-once scope; nothing internal uses it).
- **Full-stack** `simplerisk` keeps its master-push rebuild.

## Validation

- `actionlint` (promote-latest, push-to-dockerhub) — clean.
- Task-by-task review + whole-branch review (opus): verified manual-only trigger, no rebuild step, exact tag alignment with Plan 1, multi-arch-preserving retag, fail-closed guards (existence + currency), and a clean job removal with no dangling refs. The one Important finding (promote could ship a stale-but-existing version) was fixed with the currency digest guard.

## Notes

- These workflows run on **master** (the GA leg), so they take effect when `testing → master` promotes them. This PR lands them on `testing` first, consistent with #147.
- The GA promote is exercised end-to-end in **Plan 4** (the `20260709-001` landing), which asserts `:latest` and `:testing` resolve to the same digest after promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)