### PR TITLE
Allow the service endpoint URLs to be overridden per instance

### DIFF
--- a/simplerisk-minimal/common/entrypoint.sh
+++ b/simplerisk-minimal/common/entrypoint.sh
@@ -135,6 +135,51 @@ set_config(){
 			print_log "initial_setup:info" "SIMPLERISK_DEMO_MODE is set to a non-true value; demo mode NOT enabled."
 			;;
 	esac
+
+	# Optional service endpoint overrides, for instances that must talk to the
+	# test estate rather than production. Same shape as DEMO_MODE above: no
+	# placeholder in config.sample.php, appended only when supplied, so an
+	# instance that says nothing keeps the code's built-in production defaults.
+	#
+	# All five are written when supplied, on purpose. LICENSING_URL superseded
+	# SERVICES_URL and PING_URL when registration and ping were merged into the
+	# licensing service (July 2026 release) — but the platform runs different
+	# images per release channel, and an instance on an older image still reads
+	# the legacy pair. Writing whichever ones are supplied keeps one config
+	# correct across both.
+	#
+	# Every consumer is defined()-guarded with a production fallback, so a
+	# constant that a given image does not know about is simply ignored.
+	for _url_const in SERVICES_URL UPDATES_URL PING_URL BUNDLES_URL LICENSING_URL; do
+		_url_env="SIMPLERISK_${_url_const}"
+		_url_val="${!_url_env:-}"
+
+		[ -z "$_url_val" ] && continue
+
+		# Only http(s), and no quote or backslash — the value is interpolated into
+		# a single-quoted PHP string, and this is config we generate, not input we
+		# need to be clever about.
+		case "$_url_val" in
+			https://*|http://*) ;;
+			*)
+				print_log "initial_setup:info" "$_url_env is not an http(s) URL; ignoring."
+				continue
+				;;
+		esac
+		case "$_url_val" in
+			*\'*|*\\*)
+				print_log "initial_setup:info" "$_url_env contains a quote or backslash; ignoring."
+				continue
+				;;
+		esac
+
+		if grep -q "define('${_url_const}'" "$CONFIG_PATH"; then
+			print_log "initial_setup:info" "${_url_const} already present in $CONFIG_PATH; leaving it alone."
+		else
+			printf "\ndefine('%s', '%s');\n" "$_url_const" "$_url_val" >> "$CONFIG_PATH"
+			print_log "initial_setup:info" "${_url_const} set to ${_url_val}."
+		fi
+	done
 }
 
 set_csrf_secret(){


### PR DESCRIPTION
Adds five optional env vars to `simplerisk-minimal`'s `set_config()`:
`SIMPLERISK_{SERVICES,UPDATES,PING,BUNDLES,LICENSING}_URL`. Each one that is set
is written into `config.php` as `define('<NAME>', '<value>');`; each one that is
unset is left out entirely.

**Absent, not empty.** Every consumer in core is `defined()`-guarded and falls back
to a built-in production default, so `define('UPDATES_URL', '')` is worse than no
define at all — it shadows the default with an empty string and breaks the feature
with no error. There is deliberately no placeholder in `config.sample.php`, same as
`DEMO_MODE`.

**Why it's needed.** `demo.simplerisk.com` is the canary and runs the `testing`
release channel, so it boots a release-candidate image. Against the production
endpoints it compares itself to an updates feed still advertising the previous GA
release — reporting a version problem that isn't one — and registers into
production licensing. Pointing it at the test estate is what makes a pre-release
canary meaningful.

`LICENSING_URL` supersedes `SERVICES_URL` and `PING_URL`, which merged into the
licensing service in the July 2026 release. All five are supported because the
platform runs a different image per release channel, so a `latest`-channel instance
can still be on a pre-merge image that reads the legacy pair.

**Validation.** The value lands inside a single-quoted PHP literal that is eval'd on
every request, so a value that is not `http(s)://…` or that contains a quote or
backslash is logged and skipped rather than written. `simplerisk-customers-cdk`
enforces the same rule in `customers/_schema.json`, so a bad value fails at PR time
rather than silently at boot.

Tested: valid URLs written once; `not-a-url` rejected; `https://evil'; system('x'); //`
rejected; a second pass is idempotent (an already-present define is left alone, so no duplicates).