### PR TITLE
Restore HTTP access logging on the minimal image's :443 vhost

### DIFF
--- a/simplerisk-minimal/common/etc/apache2/sites-enabled/default-ssl.conf
+++ b/simplerisk-minimal/common/etc/apache2/sites-enabled/default-ssl.conf
@@ -16,6 +16,30 @@ SSLStrictSNIVHostCheck Off
         SSLCertificateKeyFile /etc/apache2/ssl/simplerisk/simplerisk.key
         SSLProtocol -all +TLSv1.2 +TLSv1.3
         SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown
+
+        # A CustomLog inside a vhost REPLACES the one inherited from the server
+        # config, so declaring only ssl_request_log below silently disabled normal
+        # access logging for every request: conf-enabled/other-vhosts-access-log.conf
+        # never applied to this vhost, and since the ALB speaks only to :443, the
+        # :80 vhost's access.log stayed empty too. Nothing recorded status codes,
+        # and nothing reached CloudWatch.
+        #
+        # access.log is a symlink to /dev/stdout in the php:apache base image, so
+        # writing here reaches the container's stdout and the awslogs driver picks
+        # it up. That is the Docker-native path -- no log-tailer entry is needed,
+        # and one tailing this file would read nothing, because /dev/stdout is a
+        # write end.
+        #
+        # %h is the load balancer, not the caller, so it is useless for "who hit
+        # this". X-Forwarded-For carries the real client. The ALB APPENDS the true
+        # peer address as the last element, so trust the last one: anything before
+        # it was supplied by the client and can be forged. Logging the whole header
+        # keeps that chain visible rather than hiding a spoof behind a single value.
+        LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" simplerisk_alb
+        CustomLog /var/log/apache2/access.log simplerisk_alb
+
+        # Kept for TLS diagnostics (protocol and cipher per request), which the
+        # combined format above does not carry.
         CustomLog /var/log/apache2/ssl_request_log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 
         Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains; preload"


### PR DESCRIPTION
## The bug

An Apache `CustomLog` inside a vhost **replaces** the one inherited from the server config. `default-ssl.conf` declared only `ssl_request_log`, so `conf-enabled/other-vhosts-access-log.conf` never applied to `:443` — and since the ALB speaks only to `:443`, the `:80` vhost's `access.log` stayed empty too.

Net effect: **no HTTP access logging anywhere** for a dedicated-hosting customer.

`ssl_request_log` was the only record of a request, and it's a poor one:

```
[13/Aug/2026:17:29:01 +0000] 10.120.0.74 TLSv1.3 TLS_AES_256_GCM_SHA384 "GET / HTTP/1.1" 1925
```

`10.120.0.74` is the load balancer, not the caller. No status code, no referer, no user agent. And nothing ships it off the container — it's a real file on the ephemeral `/var/log` volume, so it dies with the task.

## How it hid

Found while verifying `demo`'s migration: a probe request couldn't be located in CloudWatch at all.

The `log-tailer` sidecar in `simplerisk-customers-cdk` *appears* to cover this — it tails `/var/log/apache2/access.log`. It can't. That path is a symlink to `/dev/stdout` in the `php:apache` base image, and `/dev/stdout` is a write end, so the tail reads nothing forever. The sidecar entry looked like coverage while providing none.

## The fix

A combined-format `CustomLog` to `access.log`, which reaches the container's stdout and therefore the `awslogs` driver — the Docker-native path, needing no sidecar entry.

Client identity comes from `X-Forwarded-For` since `%h` is the load balancer. The **whole header** is logged deliberately: the ALB appends the true peer as the last element, so only the last one is trustworthy, and keeping the chain visible beats hiding a forged prefix behind a single value. (`mod_remoteip` would be the alternative, but it needs a trusted-proxy range that varies per region, and misconfiguring it makes spoofing win silently.)

`ssl_request_log` is kept for the TLS protocol/cipher detail the combined format doesn't carry.

## Verification

Built the image and ran `apache2ctl -t` → `Syntax OK`. Requests through the vhost emit on stdout:

```
203.0.113.9  - - [13/Aug/2026:17:35:15 +0000] "GET /?abuse-probe HTTP/1.1"      200 4031 "-" "curl/8.7.1"
198.51.100.4 - - [13/Aug/2026:17:35:15 +0000] "GET /nonexistent-page HTTP/1.1"  404  298 "-" "curl/8.7.1"
```

Including the 404 the previous configuration could not record at all.