### PR TITLE
Restore HTTP access logging on the minimal image's :443 vhost (testing)

### DIFF
--- a/simplerisk-minimal/common/etc/apache2/sites-enabled/default-ssl.conf
+++ b/simplerisk-minimal/common/etc/apache2/sites-enabled/default-ssl.conf
@@ -16,6 +16,30 @@ SSLStrictSNIVHostCheck Off
         SSLCertificateKeyFile /etc/apache2/ssl/simplerisk/simplerisk.key
         SSLProtocol -all +TLSv1.2 +TLSv1.3
         SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown
+
+        # A CustomLog inside a vhost REPLACES the one inherited from the server
+        # config, so declaring only ssl_request_log below silently disabled normal
+        # access logging for every request: conf-enabled/other-vhosts-access-log.conf
+        # never applied to this vhost, and since the ALB speaks only to :443, the
+        # :80 vhost's access.log stayed empty too. Nothing recorded status codes,
+        # and nothing reached CloudWatch.
+        #
+        # access.log is a symlink to /dev/stdout in the php:apache base image, so
+        # writing here reaches the container's stdout and the awslogs driver picks
+        # it up. That is the Docker-native path -- no log-tailer entry is needed,
+        # and one tailing this file would read nothing, because /dev/stdout is a
+        # write end.
+        #
+        # %h is the load balancer, not the caller, so it is useless for "who hit
+        # this". X-Forwarded-For carries the real client. The ALB APPENDS the true
+        # peer address as the last element, so trust the last one: anything before
+        # it was supplied by the client and can be forged. Logging the whole header
+        # keeps that chain visible rather than hiding a spoof behind a single value.
+        LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" simplerisk_alb
+        CustomLog /var/log/apache2/access.log simplerisk_alb
+
+        # Kept for TLS diagnostics (protocol and cipher per request), which the
+        # combined format above does not carry.
         CustomLog /var/log/apache2/ssl_request_log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 
         Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains; preload"


### PR DESCRIPTION
Cherry-pick of #155 onto `testing` — identical diff, see that PR for the full analysis.

**This is the one that reaches demo**, which runs `release_channel: testing`. #155 only affects the release channel.

As with #154, merging triggers *Publish simplerisk-minimal testing*, which rebuilds `20260811-001-php85` **in place** (VERSION derives from the bundle name, which hasn't changed). The ECR pull-through cache will keep serving the stale image until purged:

```
aws ecr batch-delete-image --repository-name docker-hub/simplerisk/simplerisk-minimal \
  --image-ids imageTag=20260811-001-php85 --profile simplerisk-customers-admin
aws ecs update-service --force-new-deployment ...
```