### PR TITLE
Verified bundle download with a pre-GA fallback on master

### DIFF
--- a/.github/workflows/container-validation.yml
+++ b/.github/workflows/container-validation.yml
@@ -13,7 +13,7 @@ jobs:
       context_path: "simplerisk/"
       dockerfile_path: "simplerisk/Dockerfile"
       image_tag: "simplerisk/simplerisk:testing"
-      build_args: "ubuntu_version_code=jammy"
+      build_args: "ubuntu_version_code=jammy\nPREGA_BUNDLE_FALLBACK=true"
 
   simplerisk-noble:
     name: 'Verify simplerisk/simplerisk image based on Ubuntu 24.04 (Noble)'
@@ -22,7 +22,7 @@ jobs:
       context_path: "simplerisk/"
       dockerfile_path: "simplerisk/Dockerfile"
       image_tag: "simplerisk/simplerisk:testing"
-      build_args: "ubuntu_version_code=noble"
+      build_args: "ubuntu_version_code=noble\nPREGA_BUNDLE_FALLBACK=true"
 
   simplerisk-minimal-php84:
     name: 'Verify simplerisk/simplerisk-minimal image based on PHP 8.3 with Apache'
@@ -31,7 +31,7 @@ jobs:
       context_path: "simplerisk-minimal/"
       dockerfile_path: "simplerisk-minimal/Dockerfile"
       image_tag: "simplerisk/simplerisk-minimal:testing"
-      build_args: "php_version=8.3"
+      build_args: "php_version=8.3\nPREGA_BUNDLE_FALLBACK=true"
 
   simplerisk-minimal-php85:
     name: 'Verify simplerisk/simplerisk-minimal image based on PHP 8.4 with Apache'
@@ -40,4 +40,4 @@ jobs:
       context_path: "simplerisk-minimal/"
       dockerfile_path: "simplerisk-minimal/Dockerfile"
       image_tag: "simplerisk/simplerisk-minimal:testing"
-      build_args: "php_version=8.4"
+      build_args: "php_version=8.4\nPREGA_BUNDLE_FALLBACK=true"

--- a/simplerisk-minimal/Dockerfile
+++ b/simplerisk-minimal/Dockerfile
@@ -3,10 +3,20 @@ ARG php_version=8.4
 
 FROM alpine/curl:8.12.1 AS downloader
 
+# PREGA_BUNDLE_FALLBACK is a CI-ONLY switch, default false. Pre-GA the prod bundle
+# for a new version does not exist yet (it lands in public/bundles/ only at GA). CI
+# sets this true so a pre-GA build can fall back to the testing bundle WITHOUT hash
+# verification (the release has no published hash yet). A released image is ALWAYS
+# built from the VERIFIED prod bundle and NEVER from unverified testing bytes.
+ARG PREGA_BUNDLE_FALLBACK=false
+
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
-RUN mkdir -p /var/www && \
-    curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz | tar xz -C /var/www
+# Download the prod bundle, verify its published sha256 (md5 fallback) from the
+# updates feed, then extract -- fail-closed unless PREGA_BUNDLE_FALLBACK allows the
+# pre-GA path. See common/download_and_verify_bundle.sh.
+COPY common/download_and_verify_bundle.sh /download_and_verify_bundle.sh
+RUN PREGA_BUNDLE_FALLBACK="$PREGA_BUNDLE_FALLBACK" sh /download_and_verify_bundle.sh 20260519-001
 
 FROM php:${php_version}-apache
 

--- a/simplerisk-minimal/common/download_and_verify_bundle.sh
+++ b/simplerisk-minimal/common/download_and_verify_bundle.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Download the released SimpleRisk bundle for the given version, verify it against
+# the sha256 (md5 fallback) published in the production updates feed, then extract
+# it into /var/www. Run from the alpine/curl downloader stage of the generated
+# Dockerfile.
+#
+# Fail-closed by default: a RELEASED image (PREGA_BUNDLE_FALLBACK unset/false) is
+# built ONLY from the prod bundle and ONLY if it matches its published hash -- a
+# missing prod bundle, a missing feed hash, or a mismatch aborts the build, so a
+# swapped S3 object can never be baked into a published image. The bundle (S3
+# public/bundles) and its hash (served updates feed) are stored independently.
+#
+# PRE-GA CI ONLY: before GA the prod bundle/hash for a new version do not exist
+# yet (they land at GA). When PREGA_BUNDLE_FALLBACK=true AND the prod bundle is
+# absent, fall back to the testing bundle WITHOUT verification (there is no
+# published hash to check yet) and warn loudly. This path is never taken for a
+# released image.
+set -eu
+
+VERSION="${1:?usage: download_and_verify_bundle.sh <YYYYMMDD-NNN>}"
+case "$VERSION" in
+  [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9]) : ;;
+  *) echo "ERROR: bad version format: $VERSION" >&2; exit 1 ;;
+esac
+
+FEED="https://updates.simplerisk.com/releases.xml"
+PROD_URL="https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-${VERSION}.tgz"
+TEST_URL="https://bundles-test.simplerisk.com/simplerisk-${VERSION}.tgz"
+TGZ="/tmp/simplerisk-${VERSION}.tgz"
+
+if curl -fsSL -o "$TGZ" "$PROD_URL"; then
+  echo "Downloaded prod bundle for ${VERSION}; resolving published hash from ${FEED} ..."
+  ENTRY="$(curl -fsSL "$FEED" | sed -n "/<release version=\"${VERSION}\">/,/<\/release>/p")"
+  EXPECTED="$(printf '%s\n' "$ENTRY" | grep -oE '<bundle_sha256>[0-9a-f]{64}</bundle_sha256>' | grep -oE '[0-9a-f]{64}' | head -1 || true)"
+  ALGO=sha256
+  if [ -z "$EXPECTED" ]; then
+    EXPECTED="$(printf '%s\n' "$ENTRY" | grep -oE '<bundle_md5>[0-9a-f]{32}</bundle_md5>' | grep -oE '[0-9a-f]{32}' | head -1 || true)"
+    ALGO=md5
+  fi
+  if [ -z "$EXPECTED" ]; then
+    echo "ERROR: no bundle_sha256 or bundle_md5 for ${VERSION} in ${FEED} -- refusing to extract an unverifiable prod bundle" >&2
+    exit 1
+  fi
+  ACTUAL="$(${ALGO}sum "$TGZ" | cut -d' ' -f1)"
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "ERROR: bundle ${ALGO} mismatch for ${VERSION} -- expected ${EXPECTED}, got ${ACTUAL}" >&2
+    exit 1
+  fi
+  echo "Bundle ${ALGO} verified (${ACTUAL})."
+elif [ "${PREGA_BUNDLE_FALLBACK:-false}" = "true" ]; then
+  echo "WARNING: prod bundle simplerisk-${VERSION}.tgz absent -- PRE-GA CI fallback to bundles-test (UNVERIFIED: the release has no published hash yet)." >&2
+  curl -fsSL -o "$TGZ" "$TEST_URL"
+else
+  echo "ERROR: prod bundle simplerisk-${VERSION}.tgz not found and PREGA_BUNDLE_FALLBACK != true -- refusing to build a release from unverified bytes" >&2
+  exit 1
+fi
+
+mkdir -p /var/www
+tar xzf "$TGZ" -C /var/www
+rm -f "$TGZ"
+echo "Extracted bundle to /var/www."

--- a/simplerisk-minimal/generate_dockerfile.sh
+++ b/simplerisk-minimal/generate_dockerfile.sh
@@ -23,10 +23,20 @@ if [ "$release" != "testing" ]; then
 	cat << EOF >> "${SCRIPT_LOCATION}/Dockerfile"
 FROM alpine/curl:8.12.1 AS downloader
 
+# PREGA_BUNDLE_FALLBACK is a CI-ONLY switch, default false. Pre-GA the prod bundle
+# for a new version does not exist yet (it lands in public/bundles/ only at GA). CI
+# sets this true so a pre-GA build can fall back to the testing bundle WITHOUT hash
+# verification (the release has no published hash yet). A released image is ALWAYS
+# built from the VERIFIED prod bundle and NEVER from unverified testing bytes.
+ARG PREGA_BUNDLE_FALLBACK=false
+
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
-RUN mkdir -p /var/www && \\
-    curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz | tar xz -C /var/www
+# Download the prod bundle, verify its published sha256 (md5 fallback) from the
+# updates feed, then extract -- fail-closed unless PREGA_BUNDLE_FALLBACK allows the
+# pre-GA path. See common/download_and_verify_bundle.sh.
+COPY common/download_and_verify_bundle.sh /download_and_verify_bundle.sh
+RUN PREGA_BUNDLE_FALLBACK="\$PREGA_BUNDLE_FALLBACK" sh /download_and_verify_bundle.sh $release
 
 EOF
 fi

--- a/simplerisk/Dockerfile
+++ b/simplerisk/Dockerfile
@@ -5,11 +5,18 @@ FROM alpine/curl:8.12.1 AS downloader
 
 ARG DB_LANG=en
 
+# CI-ONLY pre-GA switch (default false) -- see common/download_and_verify_bundle.sh.
+ARG PREGA_BUNDLE_FALLBACK=false
+
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
-RUN mkdir -p /var/www && \
-    curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260519-001.tgz | tar xz -C /var/www && \
-    curl -sL "https://github.com/simplerisk/database/raw/master/simplerisk-$DB_LANG-20260519-001.sql" > /simplerisk.sql
+# Download the prod bundle, verify its published sha256 (md5 fallback) from the
+# updates feed, then extract (fail-closed) -- then fetch the release SQL schema.
+# -fsSL on the SQL fetch too: without --fail, curl writes the 404 body into
+# /simplerisk.sql and the image ships an HTML error page as its schema.
+COPY common/download_and_verify_bundle.sh /download_and_verify_bundle.sh
+RUN PREGA_BUNDLE_FALLBACK="$PREGA_BUNDLE_FALLBACK" sh /download_and_verify_bundle.sh 20260519-001 && \
+    curl -fsSL "https://github.com/simplerisk/database/raw/master/simplerisk-$DB_LANG-20260519-001.sql" > /simplerisk.sql
 
 # Using Ubuntu image
 FROM ubuntu:${ubuntu_version_code}

--- a/simplerisk/common/download_and_verify_bundle.sh
+++ b/simplerisk/common/download_and_verify_bundle.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Download the released SimpleRisk bundle for the given version, verify it against
+# the sha256 (md5 fallback) published in the production updates feed, then extract
+# it into /var/www. Run from the alpine/curl downloader stage of the generated
+# Dockerfile.
+#
+# Fail-closed by default: a RELEASED image (PREGA_BUNDLE_FALLBACK unset/false) is
+# built ONLY from the prod bundle and ONLY if it matches its published hash -- a
+# missing prod bundle, a missing feed hash, or a mismatch aborts the build, so a
+# swapped S3 object can never be baked into a published image. The bundle (S3
+# public/bundles) and its hash (served updates feed) are stored independently.
+#
+# PRE-GA CI ONLY: before GA the prod bundle/hash for a new version do not exist
+# yet (they land at GA). When PREGA_BUNDLE_FALLBACK=true AND the prod bundle is
+# absent, fall back to the testing bundle WITHOUT verification (there is no
+# published hash to check yet) and warn loudly. This path is never taken for a
+# released image.
+set -eu
+
+VERSION="${1:?usage: download_and_verify_bundle.sh <YYYYMMDD-NNN>}"
+case "$VERSION" in
+  [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9]) : ;;
+  *) echo "ERROR: bad version format: $VERSION" >&2; exit 1 ;;
+esac
+
+FEED="https://updates.simplerisk.com/releases.xml"
+PROD_URL="https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-${VERSION}.tgz"
+TEST_URL="https://bundles-test.simplerisk.com/simplerisk-${VERSION}.tgz"
+TGZ="/tmp/simplerisk-${VERSION}.tgz"
+
+if curl -fsSL -o "$TGZ" "$PROD_URL"; then
+  echo "Downloaded prod bundle for ${VERSION}; resolving published hash from ${FEED} ..."
+  ENTRY="$(curl -fsSL "$FEED" | sed -n "/<release version=\"${VERSION}\">/,/<\/release>/p")"
+  EXPECTED="$(printf '%s\n' "$ENTRY" | grep -oE '<bundle_sha256>[0-9a-f]{64}</bundle_sha256>' | grep -oE '[0-9a-f]{64}' | head -1 || true)"
+  ALGO=sha256
+  if [ -z "$EXPECTED" ]; then
+    EXPECTED="$(printf '%s\n' "$ENTRY" | grep -oE '<bundle_md5>[0-9a-f]{32}</bundle_md5>' | grep -oE '[0-9a-f]{32}' | head -1 || true)"
+    ALGO=md5
+  fi
+  if [ -z "$EXPECTED" ]; then
+    echo "ERROR: no bundle_sha256 or bundle_md5 for ${VERSION} in ${FEED} -- refusing to extract an unverifiable prod bundle" >&2
+    exit 1
+  fi
+  ACTUAL="$(${ALGO}sum "$TGZ" | cut -d' ' -f1)"
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "ERROR: bundle ${ALGO} mismatch for ${VERSION} -- expected ${EXPECTED}, got ${ACTUAL}" >&2
+    exit 1
+  fi
+  echo "Bundle ${ALGO} verified (${ACTUAL})."
+elif [ "${PREGA_BUNDLE_FALLBACK:-false}" = "true" ]; then
+  echo "WARNING: prod bundle simplerisk-${VERSION}.tgz absent -- PRE-GA CI fallback to bundles-test (UNVERIFIED: the release has no published hash yet)." >&2
+  curl -fsSL -o "$TGZ" "$TEST_URL"
+else
+  echo "ERROR: prod bundle simplerisk-${VERSION}.tgz not found and PREGA_BUNDLE_FALLBACK != true -- refusing to build a release from unverified bytes" >&2
+  exit 1
+fi
+
+mkdir -p /var/www
+tar xzf "$TGZ" -C /var/www
+rm -f "$TGZ"
+echo "Extracted bundle to /var/www."

--- a/simplerisk/generate_dockerfile.sh
+++ b/simplerisk/generate_dockerfile.sh
@@ -23,11 +23,18 @@ FROM alpine/curl:8.12.1 AS downloader
 
 ARG DB_LANG=en
 
+# CI-ONLY pre-GA switch (default false) -- see common/download_and_verify_bundle.sh.
+ARG PREGA_BUNDLE_FALLBACK=false
+
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
-RUN mkdir -p /var/www && \\
-    curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-$release.tgz | tar xz -C /var/www && \\
-    curl -sL "https://github.com/simplerisk/database/raw/master/simplerisk-\$DB_LANG-$release.sql" > /simplerisk.sql
+# Download the prod bundle, verify its published sha256 (md5 fallback) from the
+# updates feed, then extract (fail-closed) -- then fetch the release SQL schema.
+# -fsSL on the SQL fetch too: without --fail, curl writes the 404 body into
+# /simplerisk.sql and the image ships an HTML error page as its schema.
+COPY common/download_and_verify_bundle.sh /download_and_verify_bundle.sh
+RUN PREGA_BUNDLE_FALLBACK="\$PREGA_BUNDLE_FALLBACK" sh /download_and_verify_bundle.sh $release && \\
+    curl -fsSL "https://github.com/simplerisk/database/raw/master/simplerisk-\$DB_LANG-$release.sql" > /simplerisk.sql
 
 EOF
 fi


### PR DESCRIPTION
## Description

`container-validation` fails on **every** release-bump PR, and has since at least `update-20260709-001`. This is the fix, ported from the `testing` branch where it already works.

### Why it fails

The image build fetched the app bundle with a bare pipe:

```
curl -sL https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-<version>.tgz | tar xz -C /var/www
```

`public/bundles/` is the **GA** path — written only by `propagate_release_bundle` at the `testing → master` cut. But `bump_downstream_versions` opens the docker `update-<version>` PR at the **testing** cut, from base `master`. So the version it pins has no prod bundle yet, and validation fails until GA.

Confirmed across three releases: `update-20260709-001`, `update-20260811-001`, `update-20260820-001` — all red, while unrelated PRs from the same weeks passed because they build against an already-published GA bundle.

Second, subtler problem: **`curl -sL` has no `--fail`**, so the S3 error document is streamed into `tar` and the failure surfaces as a tar exit code rather than an HTTP status. The real cause never appears in the log. That is precisely how this got misdiagnosed as expected-at-RC behaviour rather than a bug.

### The fix

`common/download_and_verify_bundle.sh` (identical in both build contexts, taken verbatim from `testing`) downloads the prod bundle, resolves its published `sha256` — `md5` fallback — from the prod updates feed, and verifies it before extracting.

**Fail-closed by default.** A missing prod bundle, a missing feed hash, or a hash mismatch aborts the build. A swapped S3 object therefore cannot be baked into a published image, and the bundle and its hash come from independent sources (S3 object vs. served feed).

`PREGA_BUNDLE_FALLBACK=true` — set **only** by `container-validation`, never for a released image — lets a pre-GA build fall back to `bundles-test` without verification, warning loudly. That path exists because a release genuinely has no published hash before GA.

### On PR #146

[#146](https://github.com/simplerisk/docker/pull/146) attempted this in July and was **correctly closed**. Its diff adds the `ARG`, the `COPY` and the generator changes but **never adds the script**, so it would have failed at `COPY common/download_and_verify_bundle.sh`. The complete implementation later landed on `testing` only — which is why the bug persisted on `master`, the branch the bump PRs are actually cut from.

### Ported surgically, not copied

`testing`'s versions of these files also carry changes unrelated to this bug, none of which are included here:

| Unrelated change on `testing` | Included? |
|---|---|
| PHP default `8.4` → `8.5` | ✗ |
| New `source_mode` generator parameter (`context`\|`download`) | ✗ |
| Added `php85` validation job, `php83`/`php84` job renames | ✗ |
| Trigger `branches: [master]` → `[master, testing]` | ✗ |

Verified after patching: `php_version` is still `8.4`, there are zero `source_mode` references, and the `container-validation.yml` diff is exactly the four `build_args` lines.

### Generators, not Dockerfiles

The Dockerfiles are generated (`# Dockerfile generated by script`) and `make update_version` re-runs `generate_dockerfile.sh` on every version bump. So I patched the **generators** and re-ran them to produce the Dockerfiles. Editing the Dockerfiles directly would have been silently overwritten by the next bump.

### One more defect found while in there

The full-stack image's SQL fetch had the same missing `--fail`:

```
curl -sL "https://github.com/simplerisk/database/raw/master/simplerisk-$DB_LANG-<version>.sql" > /simplerisk.sql
```

Without `--fail`, a 404 body is written to `/simplerisk.sql` and the image ships an **HTML error page as its database schema**. Now `-fsSL`.

## Validation

Ran the script in the real `alpine/curl:8.12.1` downloader image across all three paths:

| Scenario | Expected | Result |
|---|---|---|
| `PREGA_BUNDLE_FALLBACK=false`, pre-GA version | fail closed | ✅ exit 1, `refusing to build a release from unverified bytes` |
| `PREGA_BUNDLE_FALLBACK=true`, pre-GA version | fall back to `bundles-test` | ✅ exit 0, warned, `Extracted bundle to /var/www.` |
| `PREGA_BUNDLE_FALLBACK=false`, GA version present | verify hash, extract | ✅ (`20260519-001`, the current GA) |

So the security property holds in both directions: a released image can only be built from the hash-verified prod bundle, and unverified bytes require the explicit CI-only flag.

Also confirmed the surrounding facts rather than assuming them: GA is currently `20260519-001` (agreed across `code-development` `master`, the prod feed, `public/bundles/`, and this repo's pinned version), so `20260811-001` and `20260820-001` are RC-only and their absence from `public/bundles/` is correct.

`container-validation` on this PR is the live test — it builds all four images with the fallback enabled against a `master` still pinned to the current GA release, so it should exercise the **verified prod** path, not the fallback.

## Follow-up (not in this PR)

After this merges, `bump_downstream_versions` should be re-dispatched so `update-20260820-001` is regenerated from the fixed `master`. The existing branch was cut before this change and will keep failing until it is.
