### PR TITLE
ci: declare per-workflow permissions and move registry creds to environments

### DIFF
--- a/.github/workflows/container-validation.yml
+++ b/.github/workflows/container-validation.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   simplerisk-jammy:
     name: 'Verify simplerisk/simplerisk image based on Ubuntu 22.04 (Jammy)'

--- a/.github/workflows/create_new_tag.yml
+++ b/.github/workflows/create_new_tag.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ "master" ]
 
+permissions:
+  contents: write   # git tag + git push --tags
+
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -46,6 +46,7 @@ env:
 
 jobs:
   promote:
+    environment: release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -42,6 +42,7 @@ env:
 
 jobs:
   publish:
+    environment: testing
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -19,6 +19,9 @@ name: Push images to DockerHub
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # On a job that uses a reusable workflow, it seems you cannot
 # use env on a with block (https://github.com/actions/runner/issues/1189#issuecomment-1741672276)
 env:

--- a/.github/workflows/push-to-dockerhub_rw.yml
+++ b/.github/workflows/push-to-dockerhub_rw.yml
@@ -42,6 +42,7 @@ on:
 
 jobs:
   dockerhub:
+    environment: release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/push-to-gh-pkgs.yml
+++ b/.github/workflows/push-to-gh-pkgs.yml
@@ -15,6 +15,11 @@ name: Push images to GitHub Packages
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write   # callee push-to-gh-pkgs_rw pushes to ghcr.io
+  id-token: write   # callee cosign-signs via sigstore/fulcio
+
 # On a job that uses a reusable workflow, it seems you cannot
 # use env on a with block (https://github.com/actions/runner/issues/1189#issuecomment-1741672276)
 env:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: ShellCheck


### PR DESCRIPTION
Housekeeping so the repo-level default `GITHUB_TOKEN` can be set to **read-only**, plus a move of the registry credentials onto environments.

### Per-workflow `permissions:`
Every workflow now declares one explicitly. `create_new_tag.yml` is the only one that needs `contents: write` (it tags and pushes tags); the rest are `contents: read`.

One detail worth a second look: `push-to-gh-pkgs.yml` grants `packages: write` + `id-token: write` at the **caller** level. A reusable workflow can only downgrade the caller's token, never escalate — so with a bare `contents: read` caller, the callee's `ghcr.io` push and `cosign sign` would both fail. The callee's own job-level block is unchanged.

### Registry credentials → environments
The jobs that use the Docker Hub credentials now declare an environment, so those credentials are environment-scoped with a deployment-branch policy instead of repo-wide:

| workflow | environment | allowed ref |
|---|---|---|
| `publish-testing.yml` | `testing` | `testing` |
| `promote-latest.yml` | `release` | `master` |
| `push-to-dockerhub_rw.yml` | `release` | `master` |

`release` also carries a required reviewer, so a GA promotion waits on one approval. This lines up with how the AWS OIDC roles are already scoped — `simplerisk-image-promoter-latest` and `-testing` pin their `sub` to `refs/heads/master` and `refs/heads/testing`.

### Ordering note for whoever merges
The environments exist but hold no values yet — secret values can't be copied programmatically. Sequence matters:

1. Populate `DOCKER_USERNAME` + `DOCKER_TOKEN` on both the `release` and `testing` environments.
2. Merge this PR.
3. Remove the repo-level `DOCKER_USERNAME` / `DOCKER_TOKEN`.
4. Set Settings → Actions → Workflow permissions to **Read repository contents**.

Doing 3 before 1 will fail the next `publish-testing` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)